### PR TITLE
fix(tasks): normalize due dates for Motion API

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,10 @@
       "Bash(find:*)",
       "WebFetch(domain:docs.usemotion.com)",
       "Bash(timeout 3s env MOTION_MCP_TOOLS=complete npm run mcp)",
-      "Bash(npm run type-check:*)"
+      "Bash(npm run type-check:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(npm test)"
     ],
     "deny": [],
     "ask": [],

--- a/src/handlers/TaskHandler.ts
+++ b/src/handlers/TaskHandler.ts
@@ -6,7 +6,8 @@ import {
   formatMcpSuccess,
   parseTaskArgs,
   formatTaskList,
-  formatTaskDetail
+  formatTaskDetail,
+  normalizeDueDateForApi
 } from '../utils';
 import { isValidPriority, parseFilterDate, ValidPriority } from '../utils/constants';
 
@@ -157,7 +158,7 @@ export class TaskHandler extends BaseHandler {
       projectId: resolvedProjectId,
       status: taskData.status,
       priority: taskData.priority,
-      dueDate: taskData.dueDate,
+      dueDate: normalizeDueDateForApi(taskData.dueDate),
       duration: convertedDuration,
       labels: convertedLabels,
       assigneeId: taskData.assigneeId,
@@ -289,7 +290,9 @@ export class TaskHandler extends BaseHandler {
     if (params.description !== undefined) updateData.description = params.description;
     if (params.status !== undefined) updateData.status = params.status;
     if (params.priority !== undefined) updateData.priority = params.priority as any;
-    if (params.dueDate !== undefined) updateData.dueDate = params.dueDate;
+    if (params.dueDate !== undefined) {
+      updateData.dueDate = normalizeDueDateForApi(params.dueDate);
+    }
     if (params.duration !== undefined) {
       // Convert string duration to number or keep special values
       if (typeof params.duration === 'string') {

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -111,7 +111,7 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       dueDate: {
         type: "string",
-        description: "Filter by due date (for list). Format: YYYY-MM-DD or relative like 'today', 'tomorrow'"
+        description: "Due date (for create/update) or filter (for list). Date-only values are stored as end-of-day UTC. Format: YYYY-MM-DD or relative like 'today', 'tomorrow'"
       },
       labels: {
         type: "array",

--- a/src/utils/parameterUtils.ts
+++ b/src/utils/parameterUtils.ts
@@ -159,11 +159,14 @@ export function normalizeDueDateForApi(dueDate?: string | null): string | undefi
     return trimmed;
   }
 
-  const parsed = new Date(trimmed);
-  if (!Number.isNaN(parsed.getTime())) {
-    return parsed.toISOString();
+  // If the string looks like a datetime without timezone info (e.g. 'YYYY-MM-DDTHH:mm:ss')
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?$/.test(trimmed)) {
+    // Treat as end-of-day UTC for the given date
+    const datePart = trimmed.split('T')[0];
+    return `${datePart}T23:59:59.000Z`;
   }
 
+  // Otherwise, just return the original string (unparseable or unexpected format)
   return trimmed;
 }
 

--- a/tests/parameterUtils.spec.ts
+++ b/tests/parameterUtils.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parseWorkspaceArgs, parseTaskArgs, validateRequiredParams, validateParameterTypes } from '../src/utils/parameterUtils';
+import {
+  parseWorkspaceArgs,
+  parseTaskArgs,
+  validateRequiredParams,
+  validateParameterTypes,
+  normalizeDueDateForApi
+} from '../src/utils/parameterUtils';
 
 describe('parameterUtils', () => {
   it('parseWorkspaceArgs trims workspaceName', () => {
@@ -23,5 +29,17 @@ describe('parameterUtils', () => {
   it('validateParameterTypes throws for wrong types', () => {
     expect(() => validateParameterTypes({ lim: '10' }, { lim: 'number' })).toThrow(/Type validation failed/);
   });
-});
 
+  it('normalizeDueDateForApi converts date-only strings to end-of-day UTC', () => {
+    expect(normalizeDueDateForApi('2024-05-10')).toBe('2024-05-10T23:59:59.000Z');
+  });
+
+  it('normalizeDueDateForApi keeps timestamps with timezone offsets intact', () => {
+    expect(normalizeDueDateForApi('2024-05-10T12:30:00-04:00')).toBe('2024-05-10T12:30:00-04:00');
+  });
+
+  it('normalizeDueDateForApi expands relative dates', () => {
+    const result = normalizeDueDateForApi('today');
+    expect(result).toMatch(/T23:59:59\.000Z$/);
+  });
+});


### PR DESCRIPTION
This pull request introduces a utility function to consistently normalize due dates for tasks, ensuring that date-only values are stored as end-of-day UTC timestamps. The normalization is now applied when creating and updating tasks, and the behavior is documented and tested. These changes improve reliability and clarity for date handling across the API.

### Due date normalization improvements

* Added the `normalizeDueDateForApi` utility function to convert date-only and relative due date inputs (like 'today', 'tomorrow') to end-of-day UTC timestamps, while preserving explicit timestamps with offsets. (`src/utils/parameterUtils.ts`, [src/utils/parameterUtils.tsR137-R169](diffhunk://#diff-d356990d4c4690e172e48e5fedd4cab0f3d2e79e099266e007c962d3665e6d91R137-R169))
* Updated the task creation and update logic in `TaskHandler` to use `normalizeDueDateForApi`, ensuring all due dates are consistently normalized before being sent to the API. (`src/handlers/TaskHandler.ts`, [[1]](diffhunk://#diff-5e8eb142dee3e5f1a46c6a24c21714cd87c2355574167380bca57fbf855355edL160-R161) [[2]](diffhunk://#diff-5e8eb142dee3e5f1a46c6a24c21714cd87c2355574167380bca57fbf855355edL292-R295)
* Enhanced the due date parameter documentation in `tasksToolDefinition` to clarify normalization behavior for date-only values. (`src/tools/ToolDefinitions.ts`, [src/tools/ToolDefinitions.tsL114-R114](diffhunk://#diff-efe2c1deb20f382b337964ed92030a3c8622cedd2f87b59e8772c7c8e963aad6L114-R114))

### Testing and validation

* Added unit tests for `normalizeDueDateForApi` to verify correct handling of date-only strings, timestamps with offsets, and relative dates. (`tests/parameterUtils.spec.ts`, [tests/parameterUtils.spec.tsR32-R45](diffhunk://#diff-2488e453a563ead51900050f5d5a2d306399d525319a51c54cf32ea194fd10b7R32-R45))
* Updated task handler tests to assert that due dates are normalized to end-of-day UTC when creating or updating tasks. (`tests/handlers.task.spec.ts`, [[1]](diffhunk://#diff-be89ca41d2aa4ebc26bf5090721096ba45ec124c6eaee08efc6a0f96a56dad70L34-R48) [[2]](diffhunk://#diff-be89ca41d2aa4ebc26bf5090721096ba45ec124c6eaee08efc6a0f96a56dad70L65-R84)