### PR TITLE
Issue 39 frequency for reoccuring tasks are of the invalid type

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "Bash(gh pr diff:*)",
       "Bash(npm test)",
       "Bash(git commit:*)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(npm test:*)",
+      "mcp__zen__analyze"
     ],
     "deny": [],
     "ask": [],

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",
       "Bash(npm test)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "WebFetch(domain:github.com)"
     ],
     "deny": [],
     "ask": [],

--- a/src/services/motionApi.ts
+++ b/src/services/motionApi.ts
@@ -1924,8 +1924,9 @@ export class MotionApiService {
   async createRecurringTask(taskData: CreateRecurringTaskData): Promise<MotionRecurringTask> {
     try {
       // Validate frequency object before transformation
-      if (!validateFrequencyObject(taskData.frequency)) {
-        throw new Error('Invalid frequency object provided');
+      const freqValidation = validateFrequencyObject(taskData.frequency);
+      if (!freqValidation.valid) {
+        throw new Error(`Invalid frequency object: ${freqValidation.reason || 'Unknown reason'}`);
       }
 
       // Transform frequency object to API string format

--- a/src/services/motionApi.ts
+++ b/src/services/motionApi.ts
@@ -18,6 +18,7 @@ import {
   MotionPaginatedResponse
 } from '../types/motion';
 import { LOG_LEVELS, createMinimalPayload, RETRY_CONFIG, CACHE_TTL, LIMITS, ValidPriority } from '../utils/constants';
+import { transformFrequencyToApiString, validateFrequencyObject } from '../utils/frequencyTransform';
 import { mcpLog } from '../utils/logger';
 import { SimpleCache } from '../utils/cache';
 import { fetchAllPages as fetchAllPagesNew } from '../utils/paginationNew';
@@ -1922,16 +1923,33 @@ export class MotionApiService {
    */
   async createRecurringTask(taskData: CreateRecurringTaskData): Promise<MotionRecurringTask> {
     try {
+      // Validate frequency object before transformation
+      if (!validateFrequencyObject(taskData.frequency)) {
+        throw new Error('Invalid frequency object provided');
+      }
+
+      // Transform frequency object to API string format
+      const frequencyString = transformFrequencyToApiString(taskData.frequency);
+
       mcpLog(LOG_LEVELS.DEBUG, 'Creating recurring task in Motion API', {
         method: 'createRecurringTask',
         name: taskData.name,
         assigneeId: taskData.assigneeId,
-        frequency: taskData.frequency.type,
+        frequency: frequencyString,
+        originalFrequency: taskData.frequency,
         workspaceId: taskData.workspaceId
       });
 
+      // Create payload with transformed frequency while preserving other frequency fields
+      const apiPayload = {
+        ...taskData,
+        frequency: frequencyString,
+        // Preserve endDate and other fields that should be sent separately to the API
+        ...(taskData.frequency.endDate && { endDate: taskData.frequency.endDate })
+      };
+
       // Create minimal payload by removing empty/null values to avoid validation errors
-      const minimalPayload = createMinimalPayload(taskData);
+      const minimalPayload = createMinimalPayload(apiPayload);
       const response: AxiosResponse<MotionRecurringTask> = await this.requestWithRetry(() =>
         this.client.post('/recurring-tasks', minimalPayload)
       );

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -406,25 +406,39 @@ export const recurringTasksToolDefinition: McpToolDefinition = {
         properties: {
           type: {
             type: "string",
-            enum: ["daily", "weekly", "monthly", "yearly"],
-            description: "Frequency type"
-          },
-          interval: {
-            type: "number",
-            description: "Repeat every N periods"
+            enum: ["daily", "weekly", "biweekly", "monthly", "quarterly", "yearly", "custom"],
+            description: "Frequency type - supports all Motion API patterns including biweekly and quarterly"
           },
           daysOfWeek: {
             type: "array",
             items: { type: "number" },
-            description: "0-6 for Sunday-Saturday (for weekly)"
+            description: "0-6 for Sunday-Saturday. Used with daily/weekly/biweekly for specific days"
           },
           dayOfMonth: {
             type: "number",
-            description: "1-31 for monthly recurrence"
+            description: "1-31 for monthly/quarterly recurrence on specific day of month"
+          },
+          weekOfMonth: {
+            type: "string",
+            enum: ["first", "second", "third", "fourth", "last"],
+            description: "Which week of month/quarter for monthly/quarterly patterns with daysOfWeek"
+          },
+          monthOfQuarter: {
+            type: "number",
+            enum: [1, 2, 3],
+            description: "Which month of quarter (1-3) for quarterly patterns"
+          },
+          interval: {
+            type: "number",
+            description: "Legacy support: weekly with interval:2 maps to biweekly patterns"
+          },
+          customPattern: {
+            type: "string",
+            description: "Direct Motion API frequency pattern string (e.g., 'monthly_any_week_day_first_week')"
           },
           endDate: {
             type: "string",
-            description: "ISO 8601 format end date"
+            description: "ISO 8601 format end date for the recurring task"
           }
         },
         required: ["type"],

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -412,16 +412,16 @@ export const recurringTasksToolDefinition: McpToolDefinition = {
           daysOfWeek: {
             type: "array",
             items: { type: "number" },
-            description: "0-6 for Sunday-Saturday. Used with daily/weekly/biweekly for specific days"
+            description: "0-6 for Sunday-Saturday. Used with daily/weekly/biweekly for specific days, and with monthly/quarterly patterns (e.g., monthly_first_MO, quarterly_first_MO) for specifying days in those recurrence types"
           },
           dayOfMonth: {
             type: "number",
-            description: "1-31 for monthly/quarterly recurrence on specific day of month"
+            description: "1-31 for monthly recurrence on specific day of month"
           },
           weekOfMonth: {
             type: "string",
             enum: ["first", "second", "third", "fourth", "last"],
-            description: "Which week of month/quarter for monthly/quarterly patterns with daysOfWeek"
+            description: "Which week of month/quarter for monthly/quarterly patterns; daysOfWeek is optional (e.g., monthly_any_day_first_week or monthly_monday_first_week)"
           },
           monthOfQuarter: {
             type: "number",

--- a/src/types/mcp-tool-args.ts
+++ b/src/types/mcp-tool-args.ts
@@ -94,11 +94,14 @@ export interface MotionRecurringTasksArgs {
   projectId?: string;
   assigneeId?: string;
   frequency?: {
-    type: 'daily' | 'weekly' | 'monthly' | 'yearly';
-    interval?: number;
-    daysOfWeek?: number[];
-    dayOfMonth?: number;
-    endDate?: string;
+    type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+    daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
+    dayOfMonth?: number;                // 1-31 for monthly patterns
+    weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
+    monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
+    interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
+    customPattern?: string;             // Direct Motion API pattern for complex cases
+    endDate?: string;                   // ISO 8601 format end date
   };
   description?: string;
   deadlineType?: 'HARD' | 'SOFT';

--- a/src/types/mcp-tool-args.ts
+++ b/src/types/mcp-tool-args.ts
@@ -3,6 +3,8 @@
  * All individual tool types removed - only consolidated tools remain
  */
 
+import { FrequencyObject } from './motion';
+
 // Core utility types for search and context operations (used by motion_search)
 export interface SearchContentArgs {
   query: string;
@@ -93,16 +95,7 @@ export interface MotionRecurringTasksArgs {
   name?: string;
   projectId?: string;
   assigneeId?: string;
-  frequency?: {
-    type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
-    daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
-    dayOfMonth?: number;                // 1-31 for monthly patterns
-    weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
-    monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
-    interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
-    customPattern?: string;             // Direct Motion API pattern for complex cases
-    endDate?: string;                   // ISO 8601 format end date
-  };
+  frequency?: FrequencyObject;
   description?: string;
   deadlineType?: 'HARD' | 'SOFT';
   duration?: number | 'REMINDER';

--- a/src/types/motion.ts
+++ b/src/types/motion.ts
@@ -248,21 +248,23 @@ export interface MotionRecurringTask {
   labels: Array<string | {name: string}>;
 }
 
+export interface FrequencyObject {
+  type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+  daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
+  dayOfMonth?: number;                // 1-31 for monthly patterns
+  weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
+  monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
+  interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
+  customPattern?: string;             // Direct Motion API pattern for complex cases
+  endDate?: string;                   // ISO 8601 format end date
+}
+
 export interface CreateRecurringTaskData {
   name: string;
   workspaceId: string;
   projectId?: string;
   assigneeId: string;
-  frequency: {
-    type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
-    daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
-    dayOfMonth?: number;                // 1-31 for monthly patterns
-    weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
-    monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
-    interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
-    customPattern?: string;             // Direct Motion API pattern for complex cases
-    endDate?: string;                   // ISO 8601 format end date
-  };
+  frequency: FrequencyObject;
   description?: string;
   deadlineType?: 'HARD' | 'SOFT';
   duration?: number | 'NONE' | 'REMINDER';

--- a/src/types/motion.ts
+++ b/src/types/motion.ts
@@ -254,11 +254,14 @@ export interface CreateRecurringTaskData {
   projectId?: string;
   assigneeId: string;
   frequency: {
-    type: 'daily' | 'weekly' | 'monthly' | 'yearly';
-    interval?: number;
-    daysOfWeek?: number[];
-    dayOfMonth?: number;
-    endDate?: string;
+    type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+    daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
+    dayOfMonth?: number;                // 1-31 for monthly patterns
+    weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
+    monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
+    interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
+    customPattern?: string;             // Direct Motion API pattern for complex cases
+    endDate?: string;                   // ISO 8601 format end date
   };
   description?: string;
   deadlineType?: 'HARD' | 'SOFT';

--- a/src/utils/frequencyTransform.ts
+++ b/src/utils/frequencyTransform.ts
@@ -162,7 +162,7 @@ function transformMonthlyPattern(daysOfWeek?: number[], dayOfMonth?: number, wee
         return 'monthly_any_week_day_of_month';
       }
       // Multiple specific days without weekOfMonth is not supported
-      throw new Error('Unsupported multi-day monthly pattern without weekOfMonth. Please specify weekOfMonth or select a supported pattern.');
+      throw new Error('Unsupported multi-day monthly pattern without weekOfMonth. Supported patterns include: monthly_1-31 (e.g., monthly_15), monthly_first_MO, monthly_last_TU, monthly_any_week_day_of_month, monthly_any_day_first_week, etc. Please specify weekOfMonth or see https://docs.usemotion.com/cookbooks/frequency/ for more options.');
     }
   }
 
@@ -212,7 +212,11 @@ function transformQuarterlyPattern(daysOfWeek?: number[], weekOfMonth?: string, 
 
   // Explicitly reject unsupported multi-day selections
   if (daysOfWeek && daysOfWeek.length > 1 && !isWeekdaysPattern(daysOfWeek)) {
-    throw new Error('Unsupported multi-day selection for quarterly patterns: ' + JSON.stringify(daysOfWeek));
+    throw new Error(
+      'Unsupported multi-day selection for quarterly patterns: ' + JSON.stringify(daysOfWeek) +
+      '. Quarterly patterns only support a single day-of-week (e.g., "quarterly_first_MO"), weekdays (Mon-Fri, "quarterly_any_week_day_first_week"), or any day ("quarterly_any_day_first_week"). ' +
+      'Please refer to the Motion API documentation for supported quarterly patterns: https://docs.usemotion.com/cookbooks/frequency/#quarterly-patterns'
+    );
   }
 
   // Default pattern

--- a/src/utils/frequencyTransform.ts
+++ b/src/utils/frequencyTransform.ts
@@ -75,7 +75,7 @@ export function transformFrequencyToApiString(frequency: FrequencyObject): strin
       return transformMonthlyPattern(daysOfWeek, dayOfMonth, weekOfMonth);
 
     case 'quarterly':
-      return transformQuarterlyPattern(daysOfWeek, dayOfMonth, weekOfMonth, monthOfQuarter);
+      return transformQuarterlyPattern(daysOfWeek, weekOfMonth, monthOfQuarter);
 
     case 'yearly':
       // Yearly patterns are basic in the API docs
@@ -188,7 +188,7 @@ function transformMonthlyPattern(daysOfWeek?: number[], dayOfMonth?: number, wee
 /**
  * Transform quarterly frequency patterns
  */
-function transformQuarterlyPattern(daysOfWeek?: number[], dayOfMonth?: number, weekOfMonth?: string, monthOfQuarter?: number): string {
+function transformQuarterlyPattern(daysOfWeek?: number[], weekOfMonth?: string, monthOfQuarter?: number): string {
   // Handle quarterly with specific day-of-week
   if (daysOfWeek && daysOfWeek.length === 1) {
     const dayAbbrev = DAY_ABBREVIATIONS[daysOfWeek[0] as keyof typeof DAY_ABBREVIATIONS];
@@ -215,15 +215,12 @@ function transformQuarterlyPattern(daysOfWeek?: number[], dayOfMonth?: number, w
     return `quarterly_any_day_${getMonthOrdinal(monthOfQuarter)}_month`;
   }
 
-  // Default patterns
-  if (dayOfMonth) {
-    return 'quarterly_first_day'; // Closest match for specific day
-  }
-
+  // Handle remaining patterns
   if (daysOfWeek && isWeekdaysPattern(daysOfWeek)) {
     return 'quarterly_first_week_day';
   }
 
+  // Default pattern (includes dayOfMonth cases)
   return 'quarterly_first_day';
 }
 

--- a/src/utils/frequencyTransform.ts
+++ b/src/utils/frequencyTransform.ts
@@ -1,0 +1,356 @@
+/**
+ * Utility functions for transforming frequency objects to Motion API string format
+ */
+
+export interface FrequencyObject {
+  type: 'daily' | 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+  daysOfWeek?: number[];              // [0-6] for Sunday-Saturday
+  dayOfMonth?: number;                // 1-31 for monthly patterns
+  weekOfMonth?: 'first' | 'second' | 'third' | 'fourth' | 'last';  // For monthly/quarterly
+  monthOfQuarter?: 1 | 2 | 3;        // For quarterly patterns
+  interval?: number;                  // Legacy support: weekly + interval:2 → biweekly
+  customPattern?: string;             // Direct Motion API pattern for complex cases
+  endDate?: string;                   // ISO 8601 format end date
+}
+
+/**
+ * Maps day numbers (0-6) to Motion API day abbreviations
+ * 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+ */
+const DAY_ABBREVIATIONS = {
+  0: 'SU', // Sunday
+  1: 'MO', // Monday
+  2: 'TU', // Tuesday
+  3: 'WE', // Wednesday
+  4: 'TH', // Thursday
+  5: 'FR', // Friday
+  6: 'SA'  // Saturday
+} as const;
+
+/**
+ * Transforms a frequency object into the Motion API expected string format
+ *
+ * Based on Motion API documentation: https://docs.usemotion.com/cookbooks/frequency/
+ *
+ * Supports all Motion API frequency patterns including:
+ * - Daily: daily_every_day, daily_every_week_day, daily_specific_days_[...]
+ * - Weekly: weekly_any_day, weekly_any_week_day, weekly_specific_days_[...]
+ * - Biweekly: biweekly_first_week_*, biweekly_second_week_*
+ * - Monthly: monthly_1-31, monthly_first_MO, monthly_last_TU, monthly_*_week, etc.
+ * - Quarterly: quarterly_first_day, quarterly_last_FR, quarterly_any_day_first_week, etc.
+ * - Custom: Direct API pattern passthrough
+ *
+ * @param frequency - The frequency object to transform
+ * @returns The Motion API compatible frequency string
+ */
+export function transformFrequencyToApiString(frequency: FrequencyObject): string {
+  const { type, daysOfWeek, dayOfMonth, weekOfMonth, monthOfQuarter, interval, customPattern } = frequency;
+
+  // Custom pattern passthrough
+  if (type === 'custom') {
+    if (!customPattern) {
+      throw new Error('customPattern is required when type is "custom"');
+    }
+    return customPattern;
+  }
+
+  // Legacy interval mapping: weekly + interval:2 → biweekly
+  if (type === 'weekly' && interval === 2) {
+    return transformBiweeklyPattern(daysOfWeek, 'first'); // Default to first week
+  }
+
+  switch (type) {
+    case 'daily':
+      return transformDailyPattern(daysOfWeek);
+
+    case 'weekly':
+      return transformWeeklyPattern(daysOfWeek);
+
+    case 'biweekly':
+      // Use weekOfMonth to determine which week (first or second)
+      const biweeklyWeek = (weekOfMonth === 'second') ? 'second' : 'first';
+      return transformBiweeklyPattern(daysOfWeek, biweeklyWeek);
+
+    case 'monthly':
+      return transformMonthlyPattern(daysOfWeek, dayOfMonth, weekOfMonth);
+
+    case 'quarterly':
+      return transformQuarterlyPattern(daysOfWeek, dayOfMonth, weekOfMonth, monthOfQuarter);
+
+    case 'yearly':
+      // Yearly patterns are basic in the API docs
+      return 'yearly';
+
+    default:
+      throw new Error(`Unsupported frequency type: ${type}`);
+  }
+}
+
+/**
+ * Transform daily frequency patterns
+ */
+function transformDailyPattern(daysOfWeek?: number[]): string {
+  if (!daysOfWeek || daysOfWeek.length === 0) {
+    return 'daily_every_day';
+  }
+
+  // Check if it's weekdays only (Mon-Fri)
+  const isWeekdaysOnly = isWeekdaysPattern(daysOfWeek);
+  if (isWeekdaysOnly) {
+    return 'daily_every_week_day';
+  }
+
+  // Specific days
+  const dayAbbrevs = formatDayAbbreviations(daysOfWeek);
+  return `daily_specific_days_[${dayAbbrevs}]`;
+}
+
+/**
+ * Transform weekly frequency patterns
+ */
+function transformWeeklyPattern(daysOfWeek?: number[]): string {
+  if (!daysOfWeek || daysOfWeek.length === 0) {
+    return 'weekly_any_day';
+  }
+
+  // Check if it's weekdays only (Mon-Fri)
+  const isWeekdaysOnly = isWeekdaysPattern(daysOfWeek);
+  if (isWeekdaysOnly) {
+    return 'weekly_any_week_day';
+  }
+
+  // Specific days
+  const dayAbbrevs = formatDayAbbreviations(daysOfWeek);
+  return `weekly_specific_days_[${dayAbbrevs}]`;
+}
+
+/**
+ * Transform biweekly frequency patterns
+ */
+function transformBiweeklyPattern(daysOfWeek?: number[], week: 'first' | 'second' = 'first'): string {
+  if (!daysOfWeek || daysOfWeek.length === 0) {
+    return `biweekly_${week}_week_any_day`;
+  }
+
+  // Check if it's weekdays only (Mon-Fri)
+  const isWeekdaysOnly = isWeekdaysPattern(daysOfWeek);
+  if (isWeekdaysOnly) {
+    return `biweekly_${week}_week_any_week_day`;
+  }
+
+  // Specific days
+  const dayAbbrevs = formatDayAbbreviations(daysOfWeek);
+  return `biweekly_${week}_week_specific_days_[${dayAbbrevs}]`;
+}
+
+/**
+ * Transform monthly frequency patterns
+ */
+function transformMonthlyPattern(daysOfWeek?: number[], dayOfMonth?: number, weekOfMonth?: string): string {
+  // Handle monthly with specific day of month
+  if (dayOfMonth && (!daysOfWeek || daysOfWeek.length === 0)) {
+    return `monthly_${dayOfMonth}`;
+  }
+
+  // Handle monthly with day-of-week patterns
+  if (daysOfWeek && daysOfWeek.length > 0) {
+    if (weekOfMonth) {
+      // Specific week + specific day: monthly_first_MO, monthly_last_TU
+      if (daysOfWeek.length === 1) {
+        const dayAbbrev = DAY_ABBREVIATIONS[daysOfWeek[0] as keyof typeof DAY_ABBREVIATIONS];
+        return `monthly_${weekOfMonth}_${dayAbbrev}`;
+      }
+      // Specific week + multiple days (not supported directly, use week pattern)
+      if (isWeekdaysPattern(daysOfWeek)) {
+        return `monthly_any_week_day_${weekOfMonth}_week`;
+      }
+      return `monthly_any_day_${weekOfMonth}_week`;
+    } else {
+      // No week specified, use general month patterns
+      if (isWeekdaysPattern(daysOfWeek)) {
+        return 'monthly_any_week_day_of_month';
+      }
+      // Default to first week for multiple specific days
+      const dayAbbrevs = formatDayAbbreviations(daysOfWeek);
+      return `monthly_first_${dayAbbrevs.split(', ')[0]}`; // Take first day
+    }
+  }
+
+  // Handle weekOfMonth without daysOfWeek (any day of specified week)
+  if (weekOfMonth && (!daysOfWeek || daysOfWeek.length === 0)) {
+    return `monthly_any_day_${weekOfMonth}_week`;
+  }
+
+  // Default to first day of month
+  return 'monthly_1';
+}
+
+/**
+ * Transform quarterly frequency patterns
+ */
+function transformQuarterlyPattern(daysOfWeek?: number[], dayOfMonth?: number, weekOfMonth?: string, monthOfQuarter?: number): string {
+  // Handle quarterly with specific day-of-week
+  if (daysOfWeek && daysOfWeek.length === 1) {
+    const dayAbbrev = DAY_ABBREVIATIONS[daysOfWeek[0] as keyof typeof DAY_ABBREVIATIONS];
+    if (weekOfMonth === 'first') {
+      return `quarterly_first_${dayAbbrev}`;
+    }
+    if (weekOfMonth === 'last') {
+      return `quarterly_last_${dayAbbrev}`;
+    }
+    // Default to first if no week specified
+    return `quarterly_first_${dayAbbrev}`;
+  }
+
+  // Handle quarterly with week patterns
+  if (weekOfMonth) {
+    if (daysOfWeek && isWeekdaysPattern(daysOfWeek)) {
+      return `quarterly_any_week_day_${weekOfMonth}_week`;
+    }
+    return `quarterly_any_day_${weekOfMonth}_week`;
+  }
+
+  // Handle quarterly with month patterns
+  if (monthOfQuarter) {
+    return `quarterly_any_day_${getMonthOrdinal(monthOfQuarter)}_month`;
+  }
+
+  // Default patterns
+  if (dayOfMonth) {
+    return 'quarterly_first_day'; // Closest match for specific day
+  }
+
+  if (daysOfWeek && isWeekdaysPattern(daysOfWeek)) {
+    return 'quarterly_first_week_day';
+  }
+
+  return 'quarterly_first_day';
+}
+
+/**
+ * Helper: Check if daysOfWeek represents weekdays only (Mon-Fri)
+ */
+function isWeekdaysPattern(daysOfWeek: number[]): boolean {
+  return daysOfWeek.length === 5 &&
+    daysOfWeek.includes(1) && daysOfWeek.includes(2) &&
+    daysOfWeek.includes(3) && daysOfWeek.includes(4) &&
+    daysOfWeek.includes(5);
+}
+
+/**
+ * Helper: Format day numbers to abbreviations
+ */
+function formatDayAbbreviations(daysOfWeek: number[]): string {
+  return daysOfWeek
+    .map(day => DAY_ABBREVIATIONS[day as keyof typeof DAY_ABBREVIATIONS])
+    .filter(Boolean)
+    .join(', ');
+}
+
+/**
+ * Helper: Convert month number to ordinal string
+ */
+function getMonthOrdinal(month: number): string {
+  const ordinals = { 1: 'first', 2: 'second', 3: 'third' };
+  return ordinals[month as keyof typeof ordinals] || 'first';
+}
+
+/**
+ * Validates that a frequency object is valid for transformation
+ *
+ * @param frequency - The frequency object to validate
+ * @returns True if valid, false otherwise
+ */
+export function validateFrequencyObject(frequency: FrequencyObject): boolean {
+  if (!frequency.type || !['daily', 'weekly', 'biweekly', 'monthly', 'quarterly', 'yearly', 'custom'].includes(frequency.type)) {
+    return false;
+  }
+
+  // Custom type requires customPattern
+  if (frequency.type === 'custom') {
+    if (!frequency.customPattern || typeof frequency.customPattern !== 'string' || frequency.customPattern.trim() === '') {
+      return false;
+    }
+    return true; // Skip other validations for custom patterns
+  }
+
+  // Validate daysOfWeek if provided
+  if (frequency.daysOfWeek) {
+    if (!Array.isArray(frequency.daysOfWeek)) {
+      return false;
+    }
+
+    // Check that all days are valid (0-6)
+    for (const day of frequency.daysOfWeek) {
+      if (typeof day !== 'number' || day < 0 || day > 6) {
+        return false;
+      }
+    }
+  }
+
+  // Validate dayOfMonth if provided
+  if (frequency.dayOfMonth !== undefined) {
+    if (typeof frequency.dayOfMonth !== 'number' || frequency.dayOfMonth < 1 || frequency.dayOfMonth > 31) {
+      return false;
+    }
+  }
+
+  // Validate weekOfMonth if provided
+  if (frequency.weekOfMonth !== undefined) {
+    if (!['first', 'second', 'third', 'fourth', 'last'].includes(frequency.weekOfMonth)) {
+      return false;
+    }
+  }
+
+  // Validate monthOfQuarter if provided
+  if (frequency.monthOfQuarter !== undefined) {
+    if (typeof frequency.monthOfQuarter !== 'number' || frequency.monthOfQuarter < 1 || frequency.monthOfQuarter > 3) {
+      return false;
+    }
+  }
+
+  // Validate interval if provided (legacy support)
+  if (frequency.interval !== undefined) {
+    if (typeof frequency.interval !== 'number' || frequency.interval < 1) {
+      return false;
+    }
+  }
+
+  // Type-specific validations
+  switch (frequency.type) {
+    case 'quarterly':
+      // Quarterly can't use dayOfMonth alone (needs week context)
+      if (frequency.dayOfMonth && !frequency.weekOfMonth && !frequency.monthOfQuarter) {
+        return false;
+      }
+      break;
+
+    case 'biweekly':
+      // Biweekly doesn't use dayOfMonth or monthOfQuarter
+      if (frequency.dayOfMonth || frequency.monthOfQuarter) {
+        return false;
+      }
+      // Biweekly only supports 'first' and 'second' week
+      if (frequency.weekOfMonth && !['first', 'second'].includes(frequency.weekOfMonth)) {
+        return false;
+      }
+      break;
+
+    case 'daily':
+    case 'weekly':
+      // Daily/weekly don't use monthOfQuarter or weekOfMonth
+      if (frequency.monthOfQuarter || frequency.weekOfMonth) {
+        return false;
+      }
+      break;
+
+    case 'monthly':
+      // Monthly doesn't use monthOfQuarter
+      if (frequency.monthOfQuarter) {
+        return false;
+      }
+      break;
+  }
+
+  return true;
+}

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { createMinimalPayload } from '../src/utils/constants';
 import { sanitizeTextContent } from '../src/utils/sanitize';
+import { transformFrequencyToApiString, validateFrequencyObject } from '../src/utils/frequencyTransform';
 
 describe('utils', () => {
   it('createMinimalPayload removes null/empty values and preserves meaningful ones', () => {
@@ -38,5 +39,227 @@ describe('utils', () => {
     expect(sanitized).not.toContain('<b>');
     // Ensure ampersand is preserved without HTML encoding
     expect(sanitized).toContain('& more');
+  });
+
+  describe('frequencyTransform', () => {
+    describe('transformFrequencyToApiString', () => {
+      // Basic frequency types (backward compatible)
+      it('transforms basic frequency types to correct API patterns', () => {
+        expect(transformFrequencyToApiString({ type: 'daily' })).toBe('daily_every_day');
+        expect(transformFrequencyToApiString({ type: 'weekly' })).toBe('weekly_any_day');
+        expect(transformFrequencyToApiString({ type: 'monthly' })).toBe('monthly_1');
+        expect(transformFrequencyToApiString({ type: 'yearly' })).toBe('yearly');
+      });
+
+      // Daily patterns
+      it('transforms daily patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'daily', daysOfWeek: [1, 2, 3, 4, 5] })).toBe('daily_every_week_day');
+        expect(transformFrequencyToApiString({ type: 'daily', daysOfWeek: [1, 2, 3] })).toBe('daily_specific_days_[MO, TU, WE]');
+        expect(transformFrequencyToApiString({ type: 'daily', daysOfWeek: [0, 6] })).toBe('daily_specific_days_[SU, SA]');
+      });
+
+      // Weekly patterns
+      it('transforms weekly patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'weekly', daysOfWeek: [1, 2, 3, 4, 5] })).toBe('weekly_any_week_day');
+        expect(transformFrequencyToApiString({ type: 'weekly', daysOfWeek: [1, 3, 5] })).toBe('weekly_specific_days_[MO, WE, FR]');
+        expect(transformFrequencyToApiString({ type: 'weekly', daysOfWeek: [0] })).toBe('weekly_specific_days_[SU]');
+      });
+
+      // Biweekly patterns
+      it('transforms biweekly patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'biweekly' })).toBe('biweekly_first_week_any_day');
+        expect(transformFrequencyToApiString({ type: 'biweekly', daysOfWeek: [1, 2, 3, 4, 5] })).toBe('biweekly_first_week_any_week_day');
+        expect(transformFrequencyToApiString({ type: 'biweekly', daysOfWeek: [1, 3] })).toBe('biweekly_first_week_specific_days_[MO, WE]');
+
+        // Test weekOfMonth support for biweekly
+        expect(transformFrequencyToApiString({ type: 'biweekly', weekOfMonth: 'second' })).toBe('biweekly_second_week_any_day');
+        expect(transformFrequencyToApiString({ type: 'biweekly', weekOfMonth: 'second', daysOfWeek: [1, 3] })).toBe('biweekly_second_week_specific_days_[MO, WE]');
+        expect(transformFrequencyToApiString({ type: 'biweekly', weekOfMonth: 'first' })).toBe('biweekly_first_week_any_day');
+      });
+
+      // Monthly patterns
+      it('transforms monthly patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'monthly', dayOfMonth: 15 })).toBe('monthly_15');
+        expect(transformFrequencyToApiString({ type: 'monthly', dayOfMonth: 31 })).toBe('monthly_31');
+        expect(transformFrequencyToApiString({ type: 'monthly', daysOfWeek: [1], weekOfMonth: 'first' })).toBe('monthly_first_MO');
+        expect(transformFrequencyToApiString({ type: 'monthly', daysOfWeek: [5], weekOfMonth: 'last' })).toBe('monthly_last_FR');
+        expect(transformFrequencyToApiString({ type: 'monthly', daysOfWeek: [1, 2, 3, 4, 5], weekOfMonth: 'second' })).toBe('monthly_any_week_day_second_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'last' })).toBe('monthly_any_day_last_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', daysOfWeek: [1, 2, 3, 4, 5] })).toBe('monthly_any_week_day_of_month');
+
+        // Test weekOfMonth without daysOfWeek (the bug that was fixed)
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'first' })).toBe('monthly_any_day_first_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'second' })).toBe('monthly_any_day_second_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'third' })).toBe('monthly_any_day_third_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'fourth' })).toBe('monthly_any_day_fourth_week');
+        expect(transformFrequencyToApiString({ type: 'monthly', weekOfMonth: 'last' })).toBe('monthly_any_day_last_week');
+      });
+
+      // Quarterly patterns
+      it('transforms quarterly patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'quarterly' })).toBe('quarterly_first_day');
+        expect(transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [1] })).toBe('quarterly_first_MO');
+        expect(transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [5], weekOfMonth: 'last' })).toBe('quarterly_last_FR');
+        expect(transformFrequencyToApiString({ type: 'quarterly', weekOfMonth: 'first' })).toBe('quarterly_any_day_first_week');
+        expect(transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [1, 2, 3, 4, 5], weekOfMonth: 'second' })).toBe('quarterly_any_week_day_second_week');
+        expect(transformFrequencyToApiString({ type: 'quarterly', monthOfQuarter: 2 })).toBe('quarterly_any_day_second_month');
+      });
+
+      // Custom patterns
+      it('transforms custom patterns correctly', () => {
+        expect(transformFrequencyToApiString({ type: 'custom', customPattern: 'monthly_any_week_day_first_week' })).toBe('monthly_any_week_day_first_week');
+        expect(transformFrequencyToApiString({ type: 'custom', customPattern: 'quarterly_last_day' })).toBe('quarterly_last_day');
+      });
+
+      // Legacy interval support (backward compatibility)
+      it('handles legacy interval mapping for backward compatibility', () => {
+        expect(transformFrequencyToApiString({ type: 'weekly', interval: 2 })).toBe('biweekly_first_week_any_day');
+        expect(transformFrequencyToApiString({ type: 'weekly', interval: 2, daysOfWeek: [1] })).toBe('biweekly_first_week_specific_days_[MO]');
+        expect(transformFrequencyToApiString({ type: 'weekly', interval: 2, daysOfWeek: [1, 2, 3, 4, 5] })).toBe('biweekly_first_week_any_week_day');
+      });
+
+      // Edge cases
+      it('handles edge cases correctly', () => {
+        // Invalid day numbers are filtered out
+        expect(transformFrequencyToApiString({ type: 'daily', daysOfWeek: [1, 2, 8, 3, -1] })).toBe('daily_specific_days_[MO, TU, WE]');
+
+        // endDate is ignored in transformation (handled separately)
+        expect(transformFrequencyToApiString({ type: 'daily', daysOfWeek: [1, 2, 3], endDate: '2024-12-31' })).toBe('daily_specific_days_[MO, TU, WE]');
+      });
+
+      // Error cases
+      it('throws errors for invalid configurations', () => {
+        expect(() => transformFrequencyToApiString({ type: 'custom' } as any)).toThrow('customPattern is required when type is "custom"');
+        expect(() => transformFrequencyToApiString({ type: 'custom', customPattern: '' })).toThrow('customPattern is required when type is "custom"');
+      });
+    });
+
+    describe('validateFrequencyObject', () => {
+      // Basic frequency types
+      it('validates all supported frequency types', () => {
+        expect(validateFrequencyObject({ type: 'daily' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'weekly' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'biweekly' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'monthly' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'quarterly' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'yearly' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'custom', customPattern: 'monthly_last_day' })).toBe(true);
+      });
+
+      it('rejects invalid frequency types', () => {
+        expect(validateFrequencyObject({ type: 'invalid' as any })).toBe(false);
+        expect(validateFrequencyObject({ type: '' as any })).toBe(false);
+        expect(validateFrequencyObject({} as any)).toBe(false);
+        expect(validateFrequencyObject({ type: null } as any)).toBe(false);
+        expect(validateFrequencyObject({ type: undefined } as any)).toBe(false);
+      });
+
+      // Custom pattern validation
+      it('validates custom patterns', () => {
+        expect(validateFrequencyObject({ type: 'custom', customPattern: 'monthly_any_week_day_first_week' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'custom', customPattern: 'quarterly_last_day' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'custom' } as any)).toBe(false);
+        expect(validateFrequencyObject({ type: 'custom', customPattern: '' })).toBe(false);
+        expect(validateFrequencyObject({ type: 'custom', customPattern: '   ' })).toBe(false);
+      });
+
+      // Field validations
+      it('validates daysOfWeek array', () => {
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: [0, 1, 6] })).toBe(true);
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: [1, 2, 3, 4, 5] })).toBe(true);
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: [7] })).toBe(false);
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: [-1] })).toBe(false);
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: ['monday'] as any })).toBe(false);
+        expect(validateFrequencyObject({ type: 'daily', daysOfWeek: 'invalid' as any })).toBe(false);
+      });
+
+      it('validates dayOfMonth', () => {
+        expect(validateFrequencyObject({ type: 'monthly', dayOfMonth: 1 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'monthly', dayOfMonth: 31 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'monthly', dayOfMonth: 0 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'monthly', dayOfMonth: 32 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'monthly', dayOfMonth: 'first' as any })).toBe(false);
+      });
+
+      it('validates weekOfMonth', () => {
+        expect(validateFrequencyObject({ type: 'monthly', weekOfMonth: 'first' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'monthly', weekOfMonth: 'last' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'monthly', weekOfMonth: 'invalid' as any })).toBe(false);
+        expect(validateFrequencyObject({ type: 'monthly', weekOfMonth: 1 as any })).toBe(false);
+      });
+
+      it('validates monthOfQuarter', () => {
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 1 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 2 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 3 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 0 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 4 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'quarterly', monthOfQuarter: 'first' as any })).toBe(false);
+      });
+
+      it('validates interval (legacy support)', () => {
+        expect(validateFrequencyObject({ type: 'weekly', interval: 1 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'weekly', interval: 2 })).toBe(true);
+        expect(validateFrequencyObject({ type: 'weekly', interval: 0 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'weekly', interval: -1 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'weekly', interval: 'two' as any })).toBe(false);
+      });
+
+      // Type-specific field restrictions
+      it('validates type-specific field restrictions', () => {
+        // Daily/weekly don't use monthOfQuarter or weekOfMonth
+        expect(validateFrequencyObject({ type: 'daily', monthOfQuarter: 1 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'daily', weekOfMonth: 'first' })).toBe(false);
+        expect(validateFrequencyObject({ type: 'weekly', monthOfQuarter: 1 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'weekly', weekOfMonth: 'first' })).toBe(false);
+
+        // Biweekly doesn't use dayOfMonth or monthOfQuarter
+        expect(validateFrequencyObject({ type: 'biweekly', dayOfMonth: 15 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'biweekly', monthOfQuarter: 1 })).toBe(false);
+
+        // Biweekly only supports 'first' and 'second' weekOfMonth
+        expect(validateFrequencyObject({ type: 'biweekly', weekOfMonth: 'first' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'biweekly', weekOfMonth: 'second' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'biweekly', weekOfMonth: 'third' })).toBe(false);
+        expect(validateFrequencyObject({ type: 'biweekly', weekOfMonth: 'fourth' })).toBe(false);
+        expect(validateFrequencyObject({ type: 'biweekly', weekOfMonth: 'last' })).toBe(false);
+
+        // Monthly doesn't use monthOfQuarter
+        expect(validateFrequencyObject({ type: 'monthly', monthOfQuarter: 1 })).toBe(false);
+
+        // Quarterly can't use dayOfMonth alone (needs context)
+        expect(validateFrequencyObject({ type: 'quarterly', dayOfMonth: 15 })).toBe(false);
+        expect(validateFrequencyObject({ type: 'quarterly', dayOfMonth: 15, weekOfMonth: 'first' })).toBe(true);
+        expect(validateFrequencyObject({ type: 'quarterly', dayOfMonth: 15, monthOfQuarter: 1 })).toBe(true);
+      });
+
+      // Complex valid combinations
+      it('validates complex valid combinations', () => {
+        expect(validateFrequencyObject({
+          type: 'monthly',
+          daysOfWeek: [1],
+          weekOfMonth: 'first',
+          endDate: '2024-12-31'
+        })).toBe(true);
+
+        expect(validateFrequencyObject({
+          type: 'quarterly',
+          daysOfWeek: [5],
+          weekOfMonth: 'last'
+        })).toBe(true);
+
+        expect(validateFrequencyObject({
+          type: 'biweekly',
+          daysOfWeek: [1, 2, 3, 4, 5],
+          endDate: '2024-12-31'
+        })).toBe(true);
+
+        expect(validateFrequencyObject({
+          type: 'weekly',
+          interval: 2,
+          daysOfWeek: [1, 3, 5]
+        })).toBe(true);
+      });
+    });
   });
 });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -103,6 +103,8 @@ describe('utils', () => {
         expect(transformFrequencyToApiString({ type: 'quarterly', weekOfMonth: 'first' })).toBe('quarterly_any_day_first_week');
         expect(transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [1, 2, 3, 4, 5], weekOfMonth: 'second' })).toBe('quarterly_any_week_day_second_week');
         expect(transformFrequencyToApiString({ type: 'quarterly', monthOfQuarter: 2 })).toBe('quarterly_any_day_second_month');
+        // Test weekdays only (no weekOfMonth) - previously unreachable
+        expect(transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [1, 2, 3, 4, 5] })).toBe('quarterly_first_week_day');
       });
 
       // Custom patterns

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -133,6 +133,10 @@ describe('utils', () => {
       it('throws errors for invalid configurations', () => {
         expect(() => transformFrequencyToApiString({ type: 'custom' } as any)).toThrow('customPattern is required when type is "custom"');
         expect(() => transformFrequencyToApiString({ type: 'custom', customPattern: '' })).toThrow('customPattern is required when type is "custom"');
+
+        // Test improved error messages for unsupported patterns
+        expect(() => transformFrequencyToApiString({ type: 'monthly', daysOfWeek: [1, 3, 5] })).toThrow(/Supported patterns include.*monthly_1-31.*monthly_first_MO/);
+        expect(() => transformFrequencyToApiString({ type: 'quarterly', daysOfWeek: [1, 3, 5] })).toThrow(/Quarterly patterns only support.*single day-of-week.*quarterly_first_MO/);
       });
     });
 


### PR DESCRIPTION
This pull request adds robust support for advanced recurring task patterns in the Motion API integration. The main focus is on expanding the frequency object to handle all patterns supported by the Motion API, including biweekly, quarterly, and custom patterns, and introducing a utility for transforming and validating these frequency objects. The changes ensure that recurring task creation is both flexible and reliable, with validation and correct transformation of input data.

### Recurring Task Frequency Support

* Expanded the `frequency` object in `CreateRecurringTaskData`, `MotionRecurringTasksArgs`, and tool definitions to support new types (`biweekly`, `quarterly`, `custom`) and additional fields (`weekOfMonth`, `monthOfQuarter`, `customPattern`). This enables all Motion API recurrence patterns and more granular scheduling options. [[1]](diffhunk://#diff-8d2db5bf3ff53e7b4894fdc892810f6bfbfec5a36ed60b8a67f031fdce8d2932L257-R264) [[2]](diffhunk://#diff-1bbd821e19fcb82fabaa804966e92bcc64678162ec1b8afd70c9c2f6a9286efcL97-R104) [[3]](diffhunk://#diff-efe2c1deb20f382b337964ed92030a3c8622cedd2f87b59e8772c7c8e963aad6L409-R441)

* Updated the `recurringTasksToolDefinition` schema to include new frequency types and fields, improving documentation and validation for API consumers.

### Frequency Transformation and Validation

* Added a new utility module `frequencyTransform.ts` with functions to transform a frequency object into the Motion API string format and validate frequency objects before use. This ensures only valid and correctly formatted patterns are sent to the API.

* Integrated frequency transformation and validation into the `MotionApiService.createRecurringTask` method, so tasks are created with the correct API-compatible frequency string and input errors are caught early.

### Test and Import Updates

* Updated imports in relevant files (`motionApi.ts`, `utils.spec.ts`) to use the new transformation and validation utilities, and added basic test coverage for these functions. [[1]](diffhunk://#diff-dfa8ca5da22e6a7ba3078943982edde7b2732d7b8b7fba7f0d25c4fe68a7ae6eR21) [[2]](diffhunk://#diff-8a11aed3fd14509fa8b7e3166218e52d1f162a60b88151211391f28260ff71f6R5)

### Configuration

* Added `"WebFetch(domain:github.com)"` to the `.claude/settings.local.json` allowlist, likely to support new API interactions or testing.