### PR TITLE
fix(tests): update handler test mocks to match ListResult<T> shape

### DIFF
--- a/tests/handlers.project.spec.ts
+++ b/tests/handlers.project.spec.ts
@@ -5,10 +5,13 @@ import type { HandlerContext } from '../src/handlers/base/HandlerInterface';
 function makeContext(overrides: Partial<HandlerContext> = {}): HandlerContext {
   const motionService = {
     createProject: vi.fn().mockResolvedValue({ id: 'p1', name: 'Proj' }),
-    getProjects: vi.fn().mockResolvedValue([
-      { id: 'p1', name: 'A', description: '', workspaceId: 'w1' },
-      { id: 'p2', name: 'B', description: '', workspaceId: 'w1' },
-    ]),
+    getProjects: vi.fn().mockResolvedValue({
+      items: [
+        { id: 'p1', name: 'A', description: '', workspaceId: 'w1' },
+        { id: 'p2', name: 'B', description: '', workspaceId: 'w1' },
+      ],
+      truncation: undefined,
+    }),
     getProject: vi.fn().mockResolvedValue({ id: 'p1', name: 'A', description: '', workspaceId: 'w1' }),
   } as any;
 

--- a/tests/handlers.recurring.spec.ts
+++ b/tests/handlers.recurring.spec.ts
@@ -5,10 +5,13 @@ import type { MotionRecurringTasksArgs } from '../src/types/mcp-tool-args';
 
 function makeContext() {
   const motionService = {
-    getRecurringTasks: vi.fn().mockResolvedValue([
-      { id: 'rt1', name: 'Weekly Report', frequency: { type: 'weekly' }, priority: 'MEDIUM' },
-      { id: 'rt2', name: 'Daily Standup', frequency: { type: 'daily' }, priority: 'HIGH' },
-    ]),
+    getRecurringTasks: vi.fn().mockResolvedValue({
+      items: [
+        { id: 'rt1', name: 'Weekly Report', frequency: { type: 'weekly' }, priority: 'MEDIUM' },
+        { id: 'rt2', name: 'Daily Standup', frequency: { type: 'daily' }, priority: 'HIGH' },
+      ],
+      truncation: undefined,
+    }),
     createRecurringTask: vi.fn().mockResolvedValue({
       id: 'rt3',
       name: 'New Task',

--- a/tests/handlers.search.spec.ts
+++ b/tests/handlers.search.spec.ts
@@ -4,12 +4,18 @@ import type { HandlerContext } from '../src/handlers/base/HandlerInterface';
 
 function makeContext(): HandlerContext {
   const motionService = {
-    searchTasks: vi.fn().mockResolvedValue([
-      { id: 't1', name: 'Task', projectId: 'p1' },
-    ]),
-    searchProjects: vi.fn().mockResolvedValue([
-      { id: 'p1', name: 'Project', description: '', workspaceId: 'w1' },
-    ]),
+    searchTasks: vi.fn().mockResolvedValue({
+      items: [
+        { id: 't1', name: 'Task', projectId: 'p1' },
+      ],
+      truncation: undefined,
+    }),
+    searchProjects: vi.fn().mockResolvedValue({
+      items: [
+        { id: 'p1', name: 'Project', description: '', workspaceId: 'w1' },
+      ],
+      truncation: undefined,
+    }),
   } as any;
 
   const workspaceResolver = {

--- a/tests/handlers.task.spec.ts
+++ b/tests/handlers.task.spec.ts
@@ -5,10 +5,13 @@ import type { HandlerContext } from '../src/handlers/base/HandlerInterface';
 function makeContext(overrides: Partial<HandlerContext> = {}): HandlerContext {
   const motionService = {
     createTask: vi.fn().mockResolvedValue({ id: 't1', name: 'Hello' }),
-    getTasks: vi.fn().mockResolvedValue([
-      { id: 't1', name: 'A' },
-      { id: 't2', name: 'B' },
-    ]),
+    getTasks: vi.fn().mockResolvedValue({
+      items: [
+        { id: 't1', name: 'A' },
+        { id: 't2', name: 'B' },
+      ],
+      truncation: undefined,
+    }),
     getTask: vi.fn().mockResolvedValue({ id: 't1', name: 'A' }),
     updateTask: vi.fn().mockResolvedValue({ id: 't1', name: 'New' }),
     deleteTask: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- Fix 4 handler test files where mocks returned plain arrays but the handlers expect `ListResult<T>` objects (`{ items, truncation }`)
- Service methods were refactored to return paginated results but the corresponding tests weren't updated

| Test File | Mock Method |
|-----------|-------------|
| `tests/handlers.task.spec.ts` | `getTasks` |
| `tests/handlers.project.spec.ts` | `getProjects` |
| `tests/handlers.search.spec.ts` | `searchTasks`, `searchProjects` |
| `tests/handlers.recurring.spec.ts` | `getRecurringTasks` |

Fixes #74

## Test plan

- [x] `npm test` — 406/406 passing (was 402/406)