### PR TITLE
refactor: make ToolRegistry.register() private

### DIFF
--- a/src/tools/ToolRegistry.ts
+++ b/src/tools/ToolRegistry.ts
@@ -34,7 +34,7 @@ export class ToolRegistry {
    * Registers a tool definition in the registry.
    * @param tool - The tool definition to register
    */
-  register(tool: McpToolDefinition): void {
+  private register(tool: McpToolDefinition): void {
     this.tools.set(tool.name, tool);
   }
 


### PR DESCRIPTION
## Summary
- Makes `ToolRegistry.register()` private since it's only called by the private `registerAllTools()` method
- No external callers exist — the public visibility implied a contract that wasn't used

Closes #79

## Test plan
- [x] All 425 tests pass (no tests called `register()` externally — those were removed in #78)
- [x] Build succeeds (`npm run build`)