### PR TITLE
fix: surface Motion API error message on 404 responses

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -263,6 +263,11 @@ function buildUserMessage(
     if (statusCode === 401 || statusCode === 403) {
       return `${STATUS_CODE_MESSAGES[statusCode]} Unable to ${action} ${resource}${resourceInfo}.`;
     }
+    // For 404s, prefer the API message when available (e.g. "Unknown user schedule: X")
+    // since it's more actionable than the generic "resource not found"
+    if (statusCode === 404 && apiMessage) {
+      return `Unable to ${action} ${resource}${resourceInfo}. ${apiMessage}`;
+    }
     return `Unable to ${action} ${resource}${resourceInfo}. ${STATUS_CODE_MESSAGES[statusCode]}`;
   }
 

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -328,8 +328,19 @@ describe('createErrorContext', () => {
 });
 
 describe('createUserFacingError', () => {
-  it('creates error with user-friendly message for Axios 404', () => {
-    const axiosErr = fakeAxiosError(404);
+  it('creates error with user-friendly message for Axios 404 with API message', () => {
+    const axiosErr = fakeAxiosError(404, 'Unknown user schedule: Work Hours Plus');
+    const ctx = createErrorContext('fetch', 'task', 'abc123');
+    const err = createUserFacingError(axiosErr, ctx);
+
+    expect(err).toBeInstanceOf(UserFacingError);
+    expect(err.userMessage).toContain('Unable to load task');
+    expect(err.userMessage).toContain('Unknown user schedule: Work Hours Plus');
+    expect(err.code).toBe(ERROR_CODES.RESOURCE_NOT_FOUND);
+  });
+
+  it('creates error with generic message for Axios 404 without API message', () => {
+    const axiosErr = fakeAxiosError(404, '');
     const ctx = createErrorContext('fetch', 'task', 'abc123');
     const err = createUserFacingError(axiosErr, ctx);
 


### PR DESCRIPTION
## Summary
- For 404 errors, prefer the actual Motion API error message (e.g. "Unknown user schedule: Work Hours Plus") over the generic "The requested resource was not found"
- Existing behavior preserved for 404s without an API message
- Split the 404 error test into two cases covering both paths

## Context
When updating a task with `autoScheduled`, the Motion API can return a 404 with a specific message like `"Unknown user schedule: X"`. The MCP was replacing this with a generic message, making it hard to diagnose the issue.

## Test plan
- [x] All 453 unit tests pass
- [x] Verified 404 with API message surfaces the actual message
- [x] Verified 404 without API message falls back to generic "not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)