### PR TITLE
Fix Cloudflare Worker deployment: SQLite migration, SSE message routing, AJV crash

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -34,7 +34,10 @@ export class MotionMCPAgent extends McpAgent<Env> {
       registry
     );
     const enabledTools = configurator.getEnabledTools();
-    validator.initializeValidators(enabledTools);
+    // No AJV validator init here: ajv.compile() uses runtime code generation,
+    // which Cloudflare Workers disallows (EvalError). Input validation in the
+    // Worker is handled by the Zod schemas passed to server.tool() below;
+    // validateInput() is only called from the stdio entry point.
 
     for (const tool of enabledTools) {
       const zodShape = jsonSchemaToZodShape(tool.inputSchema as Parameters<typeof jsonSchemaToZodShape>[0]);
@@ -67,6 +70,22 @@ export default {
     // Validate secret path: /mcp/{secret}/...
     // Clients configure URL as: https://your-worker.workers.dev/mcp/YOUR_SECRET
     const pathParts = url.pathname.split("/").filter(Boolean);
+
+    // SSE message endpoint: the SSE stream's `endpoint` event advertises the
+    // rewritten path (/mcp/message?sessionId=...), which has no secret segment.
+    // The sessionId is unguessable and only issued on a stream opened with the
+    // secret, so it authenticates these POSTs.
+    if (
+      pathParts[0] === "mcp" &&
+      pathParts[1] === "message" &&
+      request.method === "POST" &&
+      url.searchParams.has("sessionId")
+    ) {
+      return (
+        MotionMCPAgent.mount("/mcp") as { fetch: (req: Request, env: Env, ctx: ExecutionContext) => Promise<Response> }
+      ).fetch(request, env, ctx);
+    }
+
     if (pathParts[0] !== "mcp" || pathParts[1] !== env.MOTION_MCP_SECRET) {
       return new Response("Not found", { status: 404 });
     }
@@ -77,8 +96,16 @@ export default {
     const cleanUrl = new URL(cleanPath, url.origin);
     const cleanRequest = new Request(cleanUrl, request);
 
+    // Streamable HTTP (POST/DELETE /mcp, or GET with an mcp-session-id header)
+    // is served by serve(); a bare GET on /mcp is a legacy SSE stream via mount().
+    const isStreamableHttp =
+      cleanPath === "/mcp" &&
+      (request.method !== "GET" || request.headers.has("mcp-session-id"));
+
     return (
-      MotionMCPAgent.mount("/mcp") as { fetch: (req: Request, env: Env, ctx: ExecutionContext) => Promise<Response> }
+      (isStreamableHttp
+        ? MotionMCPAgent.serve("/mcp")
+        : MotionMCPAgent.mount("/mcp")) as { fetch: (req: Request, env: Env, ctx: ExecutionContext) => Promise<Response> }
     ).fetch(cleanRequest, env, ctx);
   },
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,7 +10,7 @@ bindings = [
 
 [[migrations]]
 tag = "v1"
-new_classes = ["MotionMCPAgent"]
+new_sqlite_classes = ["MotionMCPAgent"]
 
 [vars]
 MOTION_MCP_TOOLS = "essential"


### PR DESCRIPTION
## Summary

I deployed the Worker following the README and hit three independent blockers that together make the Cloudflare deployment unusable out of the box. This PR fixes all three; with these changes the Worker deploys on a free plan and works with both the legacy SSE transport and streamable HTTP.

## 1. `wrangler.toml`: `new_classes` → `new_sqlite_classes`

`wrangler deploy` fails on Cloudflare free plans because `new_classes` requests a non-SQLite-backed Durable Object, which requires a paid plan:

```
Cannot create binding for class MotionMCPAgent that is not currently in the Workers,
you should either use new_sqlite_classes instead of new_classes... [code: 10097]
```

Switching the migration to `new_sqlite_classes` deploys everywhere (SQLite-backed DOs are the current Cloudflare recommendation regardless of plan).

## 2. `src/worker.ts`: SSE clients could never POST messages, and streamable HTTP wasn't routed

The fetch handler routed everything through `McpAgent.mount()` (legacy SSE transport only) after stripping the secret from the path. Two problems fall out of that:

- **The secret-stripping rewrite breaks the SSE message endpoint.** When a client opens the SSE stream, the agent advertises its message endpoint via the `endpoint` event — but because the agent only ever sees the rewritten URL, it advertises `/mcp/message?sessionId=...` with no secret segment. When the client then POSTs there, the worker's own secret check (`pathParts[1] !== env.MOTION_MCP_SECRET`) 404s it. Net effect: the SSE handshake succeeds but every subsequent message is rejected, so no client can actually use the server.
- **Streamable HTTP (the current MCP transport) wasn't served at all** — `mount()` only handles the legacy SSE protocol.

The fix:

- Adds a pass-through for `POST /mcp/message?sessionId=...` ahead of the secret check. The `sessionId` is an unguessable value issued only on a stream that was opened with the secret, so it authenticates these POSTs; the secret still gates opening a session.
- Routes streamable HTTP requests (`POST`/`DELETE /mcp`, or `GET` with an `mcp-session-id` header) to `McpAgent.serve()`, keeping a bare `GET /mcp` on `mount()` for legacy SSE clients.

## 3. `src/worker.ts` `init()`: remove `validator.initializeValidators()`

Every session crashed at init with:

```
EvalError: Code generation from strings disallowed for this context
```

`initializeValidators()` calls `ajv.compile()`, which generates validator functions from strings at runtime — forbidden in the Workers runtime. The call is also dead code on this path: `validateInput()` is only invoked from the stdio entry point (`src/mcp-server.ts`), and the Worker already gets input validation from the Zod schemas passed to `server.tool()`. The stdio server is untouched.

## Testing

- `wrangler deploy` succeeds on a free-plan account (previously error 10097).
- Legacy SSE: stream opens, the `endpoint` event's advertised URL now accepts POSTs, tool calls round-trip.
- Streamable HTTP: `POST /mcp` initialize + subsequent requests with `mcp-session-id` are served by `serve()`.
- Sessions no longer crash with the AJV `EvalError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
