### PR TITLE
Fix task timestamp rendering: preserve timezone info, zone-aware relative dates

### DIFF
--- a/src/handlers/TaskHandler.ts
+++ b/src/handlers/TaskHandler.ts
@@ -12,7 +12,8 @@ import {
   normalizeDueDateForApi
 } from '../utils';
 import { resolveDisplayTimeZone } from '../utils/dateFormat';
-import { isValidPriority, parseFilterDate, ValidPriority } from '../utils/constants';
+import { isValidPriority, parseFilterDate, ValidPriority, LOG_LEVELS } from '../utils/constants';
+import { mcpLog } from '../utils/logger';
 
 /** Parameters for creating a new task */
 interface CreateTaskParams {
@@ -356,7 +357,10 @@ export class TaskHandler extends BaseHandler {
   private async resolveTimeZone(): Promise<string | undefined> {
     try {
       return resolveDisplayTimeZone(await this.motionService.getSchedules());
-    } catch {
+    } catch (error) {
+      mcpLog(LOG_LEVELS.WARN, 'Timezone resolution failed, timestamps will omit local time', {
+        error: error instanceof Error ? error.message : String(error)
+      });
       return undefined;
     }
   }

--- a/src/handlers/TaskHandler.ts
+++ b/src/handlers/TaskHandler.ts
@@ -11,6 +11,7 @@ import {
   formatTaskDetail,
   normalizeDueDateForApi
 } from '../utils';
+import { resolveDisplayTimeZone } from '../utils/dateFormat';
 import { isValidPriority, parseFilterDate, ValidPriority } from '../utils/constants';
 
 /** Parameters for creating a new task */
@@ -200,13 +201,17 @@ export class TaskHandler extends BaseHandler {
       targetWorkspaceId
     );
 
+    // Zone-aware relative-date resolution ('today' means today in the account's
+    // schedule zone, not UTC). Cached lookup; failure degrades to UTC resolution.
+    const dueDateZone = taskData.dueDate ? await this.resolveTimeZone() : undefined;
+
     const task = await this.motionService.createTask({
       name: taskData.name,
       description: taskData.description,
       projectId: resolvedProjectId,
       status: taskData.status,
       priority: taskData.priority,
-      dueDate: normalizeDueDateForApi(taskData.dueDate),
+      dueDate: normalizeDueDateForApi(taskData.dueDate, dueDateZone),
       duration: convertedDuration,
       labels: convertedLabels,
       assigneeId: taskData.assigneeId,
@@ -291,7 +296,7 @@ export class TaskHandler extends BaseHandler {
     // Validate and parse due date if provided
     let validatedDueDate: string | undefined;
     if (params.dueDate) {
-      const parsedDate = parseFilterDate(params.dueDate);
+      const parsedDate = parseFilterDate(params.dueDate, await this.resolveTimeZone());
       if (!parsedDate) {
         return this.handleError(new Error(
           `Invalid date format "${params.dueDate}". Use YYYY-MM-DD format or relative dates like 'today', 'tomorrow'`
@@ -337,8 +342,23 @@ export class TaskHandler extends BaseHandler {
       priority: params.priority,
       dueDate: params.dueDate,
       limit: params.limit,
-      truncation
+      truncation,
+      timeZone: await this.resolveTimeZone()
     });
+  }
+
+  /**
+   * Resolve the IANA zone used to render local times beside ISO instants.
+   * Backed by the schedules cache, so this costs one API call per cache window.
+   * Any failure degrades to undefined — callers then emit ISO instants alone,
+   * which remain unambiguous. Display formatting must never fail a read.
+   */
+  private async resolveTimeZone(): Promise<string | undefined> {
+    try {
+      return resolveDisplayTimeZone(await this.motionService.getSchedules());
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -352,7 +372,7 @@ export class TaskHandler extends BaseHandler {
     }
 
     const taskDetails = await this.motionService.getTask(params.taskId);
-    return formatTaskDetail(taskDetails);
+    return formatTaskDetail(taskDetails, await this.resolveTimeZone());
   }
 
   /**
@@ -387,7 +407,7 @@ export class TaskHandler extends BaseHandler {
       updateData.priority = params.priority;
     }
     if (params.dueDate !== undefined) {
-      updateData.dueDate = normalizeDueDateForApi(params.dueDate);
+      updateData.dueDate = normalizeDueDateForApi(params.dueDate, await this.resolveTimeZone());
     }
     if (params.duration !== undefined) {
       updateData.duration = this.parseDurationValue(params.duration);
@@ -487,7 +507,8 @@ export class TaskHandler extends BaseHandler {
       assigneeName: display || resolvedId,
       limit: params.limit,
       allWorkspaces: true,
-      truncation
+      truncation,
+      timeZone: await this.resolveTimeZone()
     });
   }
 

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -110,7 +110,7 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       dueDate: {
         type: "string",
-        description: "Due date (for create/update) or filter (for list, filtered client-side — returns tasks due on or before this date). Date-only values are stored as end-of-day UTC. Format: YYYY-MM-DD or relative like 'today', 'tomorrow'"
+        description: "Due date (for create/update) or filter (for list, filtered client-side — returns tasks due on or before this date). Format: YYYY-MM-DD, a full ISO 8601 timestamp with offset, or relative like 'today', 'tomorrow'. A date-only value is sent as 23:59:59Z — end of day in UTC, NOT in the account's timezone. In any zone ahead of UTC that instant already falls on the following local calendar day (e.g. '2026-08-10' lands at 05:29 on 11 Aug in Asia/Kolkata). Pass an explicit ISO timestamp with an offset when the local day boundary matters. Relative keywords resolve against the account's schedule timezone when all schedules agree on one, falling back to UTC otherwise."
       },
       labels: {
         type: "array",

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -105,7 +105,7 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       priority: {
         type: "string",
-        description: "Filter by priority level (for list, filtered client-side): ASAP, HIGH, MEDIUM, LOW",
+        description: "Task priority: ASAP, HIGH, MEDIUM, LOW. Set on create/update; filters results on list (filtered client-side)",
         enum: ["ASAP", "HIGH", "MEDIUM", "LOW"]
       },
       dueDate: {
@@ -117,7 +117,7 @@ export const tasksToolDefinition: McpToolDefinition = {
         items: {
           type: "string"
         },
-        description: "Filter by labels (for list). Array of label names"
+        description: "Array of label names. Applied to the task on create/update; filters results on list"
       },
       name: {
         type: "string",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -144,25 +144,56 @@ export function isValidPriority(priority: string): priority is ValidPriority {
   return VALID_PRIORITIES.includes(priority as ValidPriority);
 }
 
-// Helper to parse and validate date formats
-export function parseFilterDate(dateInput: string): string | null {
+/**
+ * Current calendar date (YYYY-MM-DD) in the given IANA zone.
+ * Falls back to UTC when no zone is given or the runtime rejects it —
+ * identical to the pre-zone-aware behavior, so failure cannot regress anything.
+ */
+function currentDateInZone(timeZone?: string): string {
+  if (timeZone) {
+    try {
+      // en-CA formats as YYYY-MM-DD
+      return new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }).format(new Date());
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return new Date().toISOString().split('T')[0]!;
+}
+
+/** Shift a YYYY-MM-DD calendar date by whole days. Pure calendar arithmetic — DST-immune. */
+function shiftCalendarDate(date: string, days: number): string {
+  const shifted = new Date(`${date}T00:00:00Z`);
+  shifted.setUTCDate(shifted.getUTCDate() + days);
+  return shifted.toISOString().split('T')[0]!;
+}
+
+/**
+ * Helper to parse and validate date formats.
+ *
+ * Relative keywords (today/tomorrow/yesterday) resolve against the given IANA
+ * zone when supplied — without one they resolve against UTC, which in a zone
+ * ahead of UTC yields *yesterday's* local date between local midnight and the
+ * UTC day boundary (e.g. 00:00–05:29 in Asia/Kolkata).
+ */
+export function parseFilterDate(dateInput: string, timeZone?: string): string | null {
   if (!dateInput) return null;
 
   // Handle relative dates
-  const today = new Date();
   const normalizedInput = dateInput.toLowerCase().trim();
 
   switch (normalizedInput) {
     case 'today':
-      return today.toISOString().split('T')[0]!;
+      return currentDateInZone(timeZone);
     case 'tomorrow':
-      const tomorrow = new Date(today);
-      tomorrow.setDate(today.getDate() + 1);
-      return tomorrow.toISOString().split('T')[0]!;
+      return shiftCalendarDate(currentDateInZone(timeZone), 1);
     case 'yesterday':
-      const yesterday = new Date(today);
-      yesterday.setDate(today.getDate() - 1);
-      return yesterday.toISOString().split('T')[0]!;
+      return shiftCalendarDate(currentDateInZone(timeZone), -1);
   }
 
   // Validate YYYY-MM-DD format

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,126 @@
+/**
+ * Timestamp formatting utilities.
+ *
+ * Motion's REST API returns ISO 8601 instants carrying an explicit UTC
+ * designator (e.g. "2026-08-07T04:15:00.000Z"). Rendering those with
+ * `Date#toLocaleString()` resolves them against the *host* timezone and emits
+ * no zone label at all. On Cloudflare Workers the host timezone is always UTC,
+ * so the output is a UTC wall-clock reading that every downstream consumer —
+ * including an LLM — reads as local time. For a user in Asia/Kolkata that is a
+ * silent 5h30m error, and near a day boundary it reports the wrong date.
+ *
+ * These helpers never discard the offset. The ISO instant is always emitted;
+ * a human-readable local rendering is appended only when the zone is known,
+ * and is always labelled with the IANA zone ID it was rendered in.
+ */
+
+/** Matches the locale-formatted shape this module exists to eliminate. */
+export const LEGACY_LOCALE_SHAPE = /\b\d{1,2}\/\d{1,2}\/\d{4},\s+\d{1,2}:\d{2}:\d{2}\s*(AM|PM)\b/;
+
+/**
+ * Pick the zone to render local times in, given the account's schedules.
+ *
+ * Rule: render a local time only when every schedule agrees on the zone.
+ * If the schedules disagree — or none carry a zone — return undefined and let
+ * the caller emit the ISO instant alone. Silently electing a winner would
+ * reintroduce exactly the class of unlabelled-wrong-time error this module
+ * fixes; an unrendered local time is recoverable, a wrong one is not.
+ */
+export function resolveDisplayTimeZone(
+  schedules?: ReadonlyArray<{ timezone?: string | null } | null | undefined> | null
+): string | undefined {
+  if (!schedules || schedules.length === 0) return undefined;
+
+  const zones = new Set(
+    schedules
+      .map(schedule => schedule?.timezone?.trim())
+      .filter((zone): zone is string => Boolean(zone))
+  );
+
+  if (zones.size !== 1) return undefined;
+  const [zone] = [...zones];
+  return isValidTimeZone(zone!) ? zone : undefined;
+}
+
+/** True when the runtime's Intl implementation accepts this IANA zone ID. */
+export function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Render an instant as wall-clock parts in the given zone.
+ * Built from formatToParts so output does not drift with ICU locale data.
+ * Returns null if the runtime cannot honour the zone.
+ */
+function renderInZone(date: Date, timeZone: string, withTime: boolean): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23'
+    })
+      .formatToParts(date)
+      .reduce<Record<string, string>>((acc, part) => {
+        acc[part.type] = part.value;
+        return acc;
+      }, {});
+
+    if (!parts.year || !parts.month || !parts.day) return null;
+
+    const calendarDate = `${parts.year}-${parts.month}-${parts.day}`;
+    if (!withTime) return `${calendarDate} ${timeZone}`;
+    if (!parts.hour || !parts.minute || !parts.second) return null;
+
+    return `${calendarDate} ${parts.hour}:${parts.minute}:${parts.second} ${timeZone}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a full timestamp. Always emits the unambiguous ISO 8601 instant;
+ * appends a zone-labelled local rendering when a zone is supplied.
+ *
+ *   formatTimestamp('2026-08-07T04:15:00.000Z')
+ *     -> '2026-08-07T04:15:00.000Z'
+ *   formatTimestamp('2026-08-07T04:15:00.000Z', 'Asia/Kolkata')
+ *     -> '2026-08-07T04:15:00.000Z (2026-08-07 09:45:00 Asia/Kolkata)'
+ *
+ * Unparseable input is returned verbatim rather than replaced with
+ * "Invalid Date" — never destroy a value we failed to understand.
+ */
+export function formatTimestamp(value?: string | null, timeZone?: string): string {
+  if (value === undefined || value === null || value === '') return 'Not set';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+
+  const iso = date.toISOString();
+  const local = timeZone ? renderInZone(date, timeZone, true) : null;
+  return local ? `${iso} (${local})` : iso;
+}
+
+/**
+ * Format a calendar date for compact list output. The zone matters: an instant
+ * of 2026-08-10T23:59:59Z is 11 August in Asia/Kolkata, and reporting it as
+ * "8/10/2026" is an off-by-one-day error, not a cosmetic one.
+ */
+export function formatDateOnly(value?: string | null, timeZone?: string): string {
+  if (value === undefined || value === null || value === '') return 'Not set';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+
+  const local = timeZone ? renderInZone(date, timeZone, false) : null;
+  return local ?? `${date.toISOString().slice(0, 10)} UTC`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,3 +28,6 @@ export { mcpLog } from './logger';
 
 // Export truncation types
 export { TruncationInfo, ListResult } from '../types/mcp';
+
+// Date/timestamp formatting helpers
+export * from './dateFormat';

--- a/src/utils/parameterUtils.ts
+++ b/src/utils/parameterUtils.ts
@@ -139,8 +139,12 @@ export function parseTaskArgs(args: Record<string, unknown> = {}): TaskArgs {
  * Normalize date-only due dates so Motion stores them on the intended calendar day.
  * Converts relative inputs (today/tomorrow/yesterday) or YYYY-MM-DD values
  * to the end of that day in UTC. Leaves timestamps with explicit offsets intact.
+ *
+ * `timeZone` (IANA) controls which calendar day a relative keyword resolves to;
+ * the stored instant remains end-of-day UTC either way (deliberate — see the
+ * dueDate tool description). Without a zone, relative keywords resolve in UTC.
  */
-export function normalizeDueDateForApi(dueDate?: string | null): string | undefined {
+export function normalizeDueDateForApi(dueDate?: string | null, timeZone?: string): string | undefined {
   if (!dueDate) {
     return undefined;
   }
@@ -150,7 +154,7 @@ export function normalizeDueDateForApi(dueDate?: string | null): string | undefi
     return undefined;
   }
 
-  const normalizedDate = parseFilterDate(trimmed);
+  const normalizedDate = parseFilterDate(trimmed, timeZone);
   if (normalizedDate) {
     return `${normalizedDate}T23:59:59.000Z`;
   }

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -11,6 +11,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MotionProject, MotionTask, MotionWorkspace, MotionComment, MotionCustomField, MotionCustomFieldValue, MotionRecurringTask, MotionSchedule, MotionScheduleDetails, MotionStatus } from '../types/motion';
 import { TruncationInfo } from '../types/mcp';
 import { LIMITS } from './constants';
+import { formatTimestamp, formatDateOnly } from './dateFormat';
 
 const TRUNCATION_REASON_MESSAGES: Record<string, string> = {
   page_size_limit: 'due to page size limits',
@@ -109,6 +110,11 @@ interface TaskListContext {
   limit?: number;
   allWorkspaces?: boolean;
   truncation?: TruncationInfo;
+  /**
+   * IANA zone ID used to render local times alongside the ISO instant.
+   * Omitted when the account's schedules disagree — see resolveDisplayTimeZone.
+   */
+  timeZone?: string;
 }
 
 /**
@@ -118,16 +124,15 @@ export function formatTaskList(
   tasks: MotionTask[],
   context: TaskListContext = {}
 ): CallToolResult {
-  const { workspaceName, projectName, status, assigneeName, priority, dueDate, limit, allWorkspaces, truncation } = context;
-  
+  const { workspaceName, projectName, status, assigneeName, priority, dueDate, limit, allWorkspaces, truncation, timeZone } = context;
+
   const taskFormatter = (task: MotionTask) => {
     let line = `- ${task.name}`;
     if (task.id) line += ` (ID: ${task.id})`;
     if (task.status) line += ` [${typeof task.status === 'string' ? task.status : task.status.name}]`;
     if (task.priority) line += ` {${task.priority}}`;
     if (task.dueDate) {
-      const dueDate = new Date(task.dueDate).toLocaleDateString();
-      line += ` (Due: ${dueDate})`;
+      line += ` (Due: ${formatDateOnly(task.dueDate, timeZone)})`;
     }
     return line;
   };
@@ -143,11 +148,11 @@ export function formatTaskList(
   if (assigneeName) title += ` for assignee "${assigneeName}"`;
   if (priority) title += ` with priority "${priority}"`;
   if (dueDate) {
-    const parsedDueDate = new Date(dueDate);
-    const dueDateText = Number.isNaN(parsedDueDate.getTime())
-      ? dueDate
-      : parsedDueDate.toLocaleDateString();
-    title += ` due by ${dueDateText}`;
+    // The filter value is user input (a date-only string, a relative word, or an
+    // ISO timestamp) — echo it verbatim. Parsing a date-only string as an instant
+    // lands at midnight UTC, which renders as the *previous* calendar day in any
+    // zone behind UTC. Only real instants from the API go through formatDateOnly.
+    title += ` due by ${dueDate}`;
   }
   if (limit) title += ` (limit: ${limit})`;
 
@@ -210,7 +215,7 @@ export function formatDetailResponse<T extends Record<string, any>>(
 /**
  * Format single task detail response with comprehensive information
  */
-export function formatTaskDetail(task: MotionTask): CallToolResult {
+export function formatTaskDetail(task: MotionTask, timeZone?: string): CallToolResult {
   const details = [
     `Task: ${task.name}`,
     `ID: ${task.id}`,
@@ -218,10 +223,10 @@ export function formatTaskDetail(task: MotionTask): CallToolResult {
     `Status: ${typeof task.status === 'string' ? task.status : task.status?.name || 'Unknown'}`,
     `Priority: ${task.priority || 'Not set'}`,
     `Completed: ${task.completed ? 'Yes' : 'No'}`,
-    task.dueDate ? `Due Date: ${new Date(task.dueDate).toLocaleString()}` : 'Due Date: Not set',
-    task.createdTime ? `Created: ${new Date(task.createdTime).toLocaleString()}` : null,
-    task.updatedTime ? `Last Updated: ${new Date(task.updatedTime).toLocaleString()}` : null,
-    task.completedTime ? `Completed: ${new Date(task.completedTime).toLocaleString()}` : null,
+    task.dueDate ? `Due Date: ${formatTimestamp(task.dueDate, timeZone)}` : 'Due Date: Not set',
+    task.createdTime ? `Created: ${formatTimestamp(task.createdTime, timeZone)}` : null,
+    task.updatedTime ? `Last Updated: ${formatTimestamp(task.updatedTime, timeZone)}` : null,
+    task.completedTime ? `Completed: ${formatTimestamp(task.completedTime, timeZone)}` : null,
     `Workspace: ${task.workspace?.name || 'Unknown'} (${task.workspace?.id || 'N/A'})`,
     task.project ? `Project: ${task.project.name} (${task.project.id})` : 'Project: No project assigned',
     task.assignees && task.assignees.length > 0
@@ -233,8 +238,8 @@ export function formatTaskDetail(task: MotionTask): CallToolResult {
       : null,
     task.duration ? `Duration: ${typeof task.duration === 'number' ? `${task.duration} minutes` : task.duration}` : null,
     task.deadlineType ? `Deadline Type: ${task.deadlineType}` : null,
-    task.scheduledStart ? `Scheduled Start: ${new Date(task.scheduledStart).toLocaleString()}` : null,
-    task.scheduledEnd ? `Scheduled End: ${new Date(task.scheduledEnd).toLocaleString()}` : null,
+    task.scheduledStart ? `Scheduled Start: ${formatTimestamp(task.scheduledStart, timeZone)}` : null,
+    task.scheduledEnd ? `Scheduled End: ${formatTimestamp(task.scheduledEnd, timeZone)}` : null,
     task.parentRecurringTaskId ? `Recurring Task ID: ${task.parentRecurringTaskId}` : null,
     task.chunks && task.chunks.length > 0
       ? `Scheduled Chunks: ${task.chunks.length} time block(s)`

--- a/tests/dateFormat.spec.ts
+++ b/tests/dateFormat.spec.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  formatTimestamp,
+  formatDateOnly,
+  resolveDisplayTimeZone,
+  LEGACY_LOCALE_SHAPE
+} from '../src/utils/dateFormat';
+import { formatTaskDetail, formatTaskList } from '../src/utils/responseFormatters';
+import { parseFilterDate } from '../src/utils/constants';
+import { normalizeDueDateForApi } from '../src/utils/parameterUtils';
+
+const text = (res: any): string => (res.content?.[0] as any)?.text || '';
+
+// The exact instants observed on task tk_69txhSQfPDgkk8aWzDycx7.
+// Under the old code these rendered as '8/7/2026, 4:15:00 AM' and
+// '8/5/2026, 6:29:00 PM' — UTC wall-clock readings with no zone label.
+const SCHEDULED_START = '2026-08-07T04:15:00.000Z'; // 09:45 Asia/Kolkata
+const DUE_AT_UTC_EOD = '2026-08-10T23:59:59.000Z';  // 11 Aug in Asia/Kolkata
+const IST = 'Asia/Kolkata';
+
+describe('formatTimestamp', () => {
+  it('always emits the ISO instant, offset intact', () => {
+    expect(formatTimestamp(SCHEDULED_START)).toBe(SCHEDULED_START);
+  });
+
+  it('appends a zone-labelled local rendering when a zone is known', () => {
+    expect(formatTimestamp(SCHEDULED_START, IST)).toBe(
+      `${SCHEDULED_START} (2026-08-07 09:45:00 Asia/Kolkata)`
+    );
+  });
+
+  it('never emits the unlabelled locale shape that caused the defect', () => {
+    expect(formatTimestamp(SCHEDULED_START)).not.toMatch(LEGACY_LOCALE_SHAPE);
+    expect(formatTimestamp(SCHEDULED_START, IST)).not.toMatch(LEGACY_LOCALE_SHAPE);
+  });
+
+  it('resolves a non-UTC zone without hardcoding any offset', () => {
+    // Two zones, two different local readings, one identical instant.
+    expect(formatTimestamp(SCHEDULED_START, 'America/New_York')).toContain('2026-08-07 00:15:00');
+    expect(formatTimestamp(SCHEDULED_START, 'Asia/Tokyo')).toContain('2026-08-07 13:15:00');
+    expect(formatTimestamp(SCHEDULED_START, 'America/New_York')).toContain(SCHEDULED_START);
+  });
+
+  it('honours DST transitions rather than a fixed offset', () => {
+    // New York is UTC-4 in August, UTC-5 in January. A hardcoded offset fails this.
+    expect(formatTimestamp('2026-01-15T12:00:00.000Z', 'America/New_York')).toContain('07:00:00');
+    expect(formatTimestamp('2026-07-15T12:00:00.000Z', 'America/New_York')).toContain('08:00:00');
+  });
+
+  it('returns unparseable input verbatim instead of "Invalid Date"', () => {
+    expect(formatTimestamp('not-a-date')).toBe('not-a-date');
+    expect(formatTimestamp('not-a-date', IST)).toBe('not-a-date');
+  });
+
+  it('falls back to the ISO instant when the zone is unusable', () => {
+    expect(formatTimestamp(SCHEDULED_START, 'Not/AZone')).toBe(SCHEDULED_START);
+  });
+
+  it('handles empty and absent values', () => {
+    expect(formatTimestamp(undefined)).toBe('Not set');
+    expect(formatTimestamp(null)).toBe('Not set');
+    expect(formatTimestamp('')).toBe('Not set');
+  });
+});
+
+describe('formatDateOnly', () => {
+  it('reports the calendar date in the target zone, not in UTC', () => {
+    // This is the off-by-one-day bug: 23:59:59Z on the 10th is the 11th in IST.
+    expect(formatDateOnly(DUE_AT_UTC_EOD, IST)).toBe('2026-08-11 Asia/Kolkata');
+  });
+
+  it('labels the zone when none is supplied rather than implying local time', () => {
+    expect(formatDateOnly(DUE_AT_UTC_EOD)).toBe('2026-08-10 UTC');
+  });
+});
+
+describe('resolveDisplayTimeZone', () => {
+  it('uses the zone when every schedule agrees', () => {
+    expect(
+      resolveDisplayTimeZone([
+        { timezone: 'Asia/Kolkata' },
+        { timezone: 'Asia/Kolkata' }
+      ])
+    ).toBe('Asia/Kolkata');
+  });
+
+  it('refuses to elect a winner when schedules disagree', () => {
+    expect(
+      resolveDisplayTimeZone([
+        { timezone: 'Asia/Kolkata' },
+        { timezone: 'America/New_York' }
+      ])
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for empty, missing, or blank zones', () => {
+    expect(resolveDisplayTimeZone([])).toBeUndefined();
+    expect(resolveDisplayTimeZone(undefined)).toBeUndefined();
+    expect(resolveDisplayTimeZone([{ timezone: '  ' }, { timezone: null }])).toBeUndefined();
+  });
+
+  it('rejects a zone the runtime cannot honour', () => {
+    expect(resolveDisplayTimeZone([{ timezone: 'Mars/Olympus' }])).toBeUndefined();
+  });
+});
+
+describe('task formatters — regression against the reported defect', () => {
+  const task: any = {
+    id: 'tk_test',
+    name: 'Probe',
+    status: 'Todo',
+    priority: 'HIGH',
+    completed: false,
+    dueDate: DUE_AT_UTC_EOD,
+    scheduledStart: SCHEDULED_START,
+    scheduledEnd: '2026-08-07T04:30:00.000Z',
+    createdTime: '2026-08-03T05:32:25.000Z',
+    workspace: { id: 'w1', name: 'My Tasks' }
+  };
+
+  it('formatTaskDetail emits ISO instants and a labelled local time', () => {
+    const out = text(formatTaskDetail(task, IST));
+
+    expect(out).toContain(`Scheduled Start: ${SCHEDULED_START} (2026-08-07 09:45:00 Asia/Kolkata)`);
+    expect(out).toContain('Scheduled End: 2026-08-07T04:30:00.000Z (2026-08-07 10:00:00 Asia/Kolkata)');
+    expect(out).toContain(`Due Date: ${DUE_AT_UTC_EOD}`);
+  });
+
+  it('formatTaskDetail emits no unlabelled locale timestamps at all', () => {
+    expect(text(formatTaskDetail(task, IST))).not.toMatch(LEGACY_LOCALE_SHAPE);
+    expect(text(formatTaskDetail(task))).not.toMatch(LEGACY_LOCALE_SHAPE);
+  });
+
+  it('formatTaskDetail output does not depend on the host timezone', () => {
+    // Every rendered instant is explicit, so the same input yields the same
+    // string whatever TZ the Worker or test runner happens to be in.
+    expect(text(formatTaskDetail(task, IST))).toContain(SCHEDULED_START);
+    expect(text(formatTaskDetail(task))).toContain(SCHEDULED_START);
+  });
+
+  it('formatTaskList reports the due date on the correct local day', () => {
+    const out = text(formatTaskList([task], { timeZone: IST }));
+
+    expect(out).toContain('(Due: 2026-08-11 Asia/Kolkata)');
+    expect(out).not.toContain('8/10/2026');
+    expect(out).not.toMatch(LEGACY_LOCALE_SHAPE);
+  });
+
+  it('formatTaskList echoes the due-date filter verbatim in the title', () => {
+    // A date-only filter string parsed as an instant is midnight UTC — the
+    // previous calendar day in any zone behind UTC. Filter values are user
+    // input, not instants, so they are echoed rather than parsed.
+    const out = text(formatTaskList([task], { timeZone: 'America/New_York', dueDate: '2026-08-10' }));
+
+    expect(out).toContain('due by 2026-08-10');
+    expect(out).not.toContain('2026-08-09');
+
+    const relative = text(formatTaskList([task], { timeZone: IST, dueDate: 'today' }));
+    expect(relative).toContain('due by today');
+  });
+});
+
+describe('zone-aware relative dates (parseFilterDate / normalizeDueDateForApi)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 2026-08-06 20:00 UTC = 2026-08-07 01:30 in Asia/Kolkata — the exact window
+  // where UTC-anchored resolution wrote yesterday's date.
+  const IST_EARLY_MORNING = new Date('2026-08-06T20:00:00.000Z');
+
+  it("resolves 'today' in the supplied zone, not UTC", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(IST_EARLY_MORNING);
+
+    expect(parseFilterDate('today', IST)).toBe('2026-08-07');
+    expect(parseFilterDate('tomorrow', IST)).toBe('2026-08-08');
+    expect(parseFilterDate('yesterday', IST)).toBe('2026-08-06');
+  });
+
+  it('keeps UTC resolution when no zone is supplied (legacy behavior)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(IST_EARLY_MORNING);
+
+    expect(parseFilterDate('today')).toBe('2026-08-06');
+  });
+
+  it('works for zones behind UTC without hardcoding any offset', () => {
+    vi.useFakeTimers();
+    // 2026-08-07 02:00 UTC = 2026-08-06 22:00 in America/New_York
+    vi.setSystemTime(new Date('2026-08-07T02:00:00.000Z'));
+
+    expect(parseFilterDate('today', 'America/New_York')).toBe('2026-08-06');
+    expect(parseFilterDate('today')).toBe('2026-08-07');
+  });
+
+  it('falls back to UTC resolution when the zone is unusable', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(IST_EARLY_MORNING);
+
+    expect(parseFilterDate('today', 'Not/AZone')).toBe('2026-08-06');
+  });
+
+  it('leaves explicit dates untouched by the zone', () => {
+    expect(parseFilterDate('2026-08-10', IST)).toBe('2026-08-10');
+  });
+
+  it("normalizeDueDateForApi picks the zone's calendar day but still stores end-of-day UTC (D7)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(IST_EARLY_MORNING);
+
+    // The calendar day comes from the zone; the stored instant stays 23:59:59Z.
+    expect(normalizeDueDateForApi('today', IST)).toBe('2026-08-07T23:59:59.000Z');
+    expect(normalizeDueDateForApi('today')).toBe('2026-08-06T23:59:59.000Z');
+    // Full ISO input passes through byte-identical regardless of zone.
+    expect(normalizeDueDateForApi('2026-08-05T18:29:00.000Z', IST)).toBe('2026-08-05T18:29:00.000Z');
+  });
+});


### PR DESCRIPTION
## Summary

Task formatters render Motion's UTC instants with `toLocaleString()` / `toLocaleDateString()` (`src/utils/responseFormatters.ts`), which resolve against the host timezone — always UTC on Cloudflare Workers — and emit no zone label. Consumers, including LLM clients, read the output as local time: a silent 5h30m error at UTC+5:30. Near day boundaries `toLocaleDateString()` reports the wrong calendar date, so list and detail views disagree about which day a task is due.

The codebase already handles this correctly elsewhere — comment formatters pass `createdAt` through raw. Only task formatting is affected.

## What this changes

- Task timestamps always emit the ISO 8601 instant, appending a zone-labelled local rendering when all the account's schedules (`GET /schedules`, cached) agree on an IANA zone: `2026-08-07T07:45:00.000Z (2026-08-07 13:15:00 Asia/Kolkata)`. Zone disagreement or any lookup failure degrades to the bare ISO instant — display formatting never fails a read. No hardcoded offsets (enforced by tests, including a DST-shift assertion).
- List titles echo due-date filter input verbatim instead of parsing it (a date-only string parsed as an instant is midnight UTC — the previous calendar day in zones behind UTC).
- Relative `dueDate` keywords (today/tomorrow/yesterday) resolve in the account schedule zone, falling back to UTC. The stored instant for date-only values remains end-of-day UTC — deliberately unchanged; the `dueDate` description now documents that consequence.
- Second commit: the `priority`/`labels` schema descriptions read as list-only filters while `TaskHandler` forwards both on create/update — a caller composing from the description drops them silently, no error.

## Repro

Call `motion_tasks` `get` on any task with a `scheduledStart`, from a Worker deployment, with a Motion account in a non-UTC timezone. Compare the returned Scheduled Start against the same block in Google Calendar.

## Verification

- 477/477 unit tests (24 new cases in `tests/dateFormat.spec.ts`, including regressions that fail against the old formatters)
- Both tsconfigs type-check (`tsc --noEmit`, main + worker)
- Running in production on our fork since 7 Aug 2026, verified live against an Asia/Kolkata account

Offered as-is in case it's useful — this runs on our fork either way, so feel free to take it, adapt it, or leave it. (The fork also carries an OAuth 2.1 layer for claude.ai custom-connector auth, kept out of this PR deliberately; happy to share separately if of interest.)
