### PR TITLE
Surface scheduling fields and attach structuredContent to task responses

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -195,9 +195,14 @@ export function formatMcpError(error: Error | unknown): CallToolResult {
 
 /**
  * Format a success response for MCP protocol
+ *
+ * The optional `structuredContent` is attached alongside the human-readable text
+ * so machine consumers (dashboards, at-risk math) can index into fields directly
+ * instead of parsing prose. MCP's CallToolResult supports it natively; callers
+ * that omit it get the original text-only behavior unchanged.
  */
-export function formatMcpSuccess(text: string): CallToolResult {
-  return {
+export function formatMcpSuccess(text: string, structuredContent?: Record<string, unknown>): CallToolResult {
+  const result: CallToolResult = {
     content: [
       {
         type: MCP_RESPONSE_TYPES.TEXT,
@@ -205,6 +210,10 @@ export function formatMcpSuccess(text: string): CallToolResult {
       }
     ]
   };
+  if (structuredContent !== undefined) {
+    result.structuredContent = structuredContent;
+  }
+  return result;
 }
 
 // ─── User-Facing Error Factories ────────────────────────────────────────────

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -129,6 +129,11 @@ export function formatTaskList(
       const dueDate = new Date(task.dueDate).toLocaleDateString();
       line += ` (Due: ${dueDate})`;
     }
+    // Scheduling fields let a single list sweep compute both overdue and at-risk,
+    // avoiding per-task `get` calls against Motion's 12 req/min individual limit.
+    if (task.startOn) line += ` (Start On: ${new Date(task.startOn).toLocaleDateString()})`;
+    if (task.scheduledEnd) line += ` (Scheduled End: ${new Date(task.scheduledEnd).toLocaleString()})`;
+    if (task.schedulingIssue) line += ` [SCHEDULING ISSUE]`;
     return line;
   };
   
@@ -155,7 +160,12 @@ export function formatTaskList(
   let responseText = `${title}:\n${list}`;
   responseText += formatTruncationNotice(truncation);
 
-  return formatMcpSuccess(responseText);
+  const structuredContent = {
+    count: tasks.length,
+    tasks: tasks.map(taskToStructuredContent)
+  };
+
+  return formatMcpSuccess(responseText, structuredContent);
 }
 
 /**
@@ -208,6 +218,50 @@ export function formatDetailResponse<T extends Record<string, any>>(
 }
 
 /**
+ * Normalize a task's labels to a plain string array (labels may arrive as
+ * strings or as `{ name }` objects).
+ */
+function normalizeLabels(labels: MotionTask['labels']): string[] {
+  if (!Array.isArray(labels)) return [];
+  return labels.map(l => (typeof l === 'string' ? l : l.name));
+}
+
+/**
+ * Build the machine-readable projection of a task for `structuredContent`.
+ *
+ * Timestamps are passed through as the raw ISO 8601 strings Motion returns —
+ * NOT localized — so consumers get unambiguous, timezone-safe values to compute
+ * overdue/at-risk state from. `schedulingIssue` is the key signal for tasks
+ * Motion could not fit (which have no `scheduledEnd` at all).
+ */
+export function taskToStructuredContent(task: MotionTask): Record<string, unknown> {
+  return {
+    id: task.id,
+    name: task.name,
+    status: typeof task.status === 'string' ? task.status : task.status?.name ?? null,
+    completed: task.completed ?? false,
+    priority: task.priority ?? null,
+    dueDate: task.dueDate ?? null,
+    deadlineType: task.deadlineType ?? null,
+    duration: task.duration ?? null,
+    scheduledStart: task.scheduledStart ?? null,
+    scheduledEnd: task.scheduledEnd ?? null,
+    schedulingIssue: task.schedulingIssue ?? false,
+    startOn: task.startOn ?? null,
+    labels: normalizeLabels(task.labels),
+    chunks: Array.isArray(task.chunks)
+      ? task.chunks.map(chunk => ({
+          scheduledStart: chunk.scheduledStart,
+          scheduledEnd: chunk.scheduledEnd,
+          duration: chunk.duration,
+          isFixed: chunk.isFixed,
+          completedTime: chunk.completedTime ?? null
+        }))
+      : []
+  };
+}
+
+/**
  * Format single task detail response with comprehensive information
  */
 export function formatTaskDetail(task: MotionTask): CallToolResult {
@@ -233,11 +287,17 @@ export function formatTaskDetail(task: MotionTask): CallToolResult {
       : null,
     task.duration ? `Duration: ${typeof task.duration === 'number' ? `${task.duration} minutes` : task.duration}` : null,
     task.deadlineType ? `Deadline Type: ${task.deadlineType}` : null,
+    task.startOn ? `Start On: ${new Date(task.startOn).toLocaleString()}` : null,
     task.scheduledStart ? `Scheduled Start: ${new Date(task.scheduledStart).toLocaleString()}` : null,
     task.scheduledEnd ? `Scheduled End: ${new Date(task.scheduledEnd).toLocaleString()}` : null,
+    // The single most important signal for at-risk detection: unschedulable tasks
+    // have no scheduledEnd, so this flag is the only indication Motion couldn't fit them.
+    task.schedulingIssue ? `Scheduling Issue: Yes (Motion could not fit this task in the schedule)` : null,
     task.parentRecurringTaskId ? `Recurring Task ID: ${task.parentRecurringTaskId}` : null,
     task.chunks && task.chunks.length > 0
-      ? `Scheduled Chunks: ${task.chunks.length} time block(s)`
+      ? `Scheduled Chunks: ${task.chunks.length} time block(s)\n${task.chunks.map((chunk, i) =>
+          `  - Chunk ${i + 1}: ${new Date(chunk.scheduledStart).toLocaleString()} → ${new Date(chunk.scheduledEnd).toLocaleString()}${chunk.isFixed ? ' (fixed)' : ''}`
+        ).join('\n')}`
       : null,
     task.customFieldValues && Object.keys(task.customFieldValues).length > 0
       ? `Custom Fields:\n${Object.entries(task.customFieldValues).map(([valueId, cfv]) =>
@@ -246,7 +306,7 @@ export function formatTaskDetail(task: MotionTask): CallToolResult {
       : null
   ].filter(Boolean).join('\n');
 
-  return formatMcpSuccess(details);
+  return formatMcpSuccess(details, taskToStructuredContent(task));
 }
 
 interface SearchOptions {

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -131,7 +131,7 @@ export function formatTaskList(
     }
     // Scheduling fields let a single list sweep compute both overdue and at-risk,
     // avoiding per-task `get` calls against Motion's 12 req/min individual limit.
-    if (task.startOn) line += ` (Start On: ${new Date(task.startOn).toLocaleDateString()})`;
+    if (task.startOn) line += ` (Start On: ${formatDateOnly(task.startOn)})`;
     if (task.scheduledEnd) line += ` (Scheduled End: ${new Date(task.scheduledEnd).toLocaleString()})`;
     if (task.schedulingIssue) line += ` [SCHEDULING ISSUE]`;
     return line;
@@ -227,6 +227,24 @@ function normalizeLabels(labels: MotionTask['labels']): string[] {
 }
 
 /**
+ * Render a date-only field (e.g. `startOn`, which Motion returns as "2026-08-31").
+ *
+ * `new Date("2026-08-31")` parses as UTC midnight, so formatting it in a zone
+ * behind UTC lands on the PREVIOUS day ("8/30/2026, 8:00:00 PM" in US Eastern).
+ * Building the date from its parts keeps it in local time, so the calendar date
+ * is preserved and no misleading time-of-day is shown.
+ */
+function formatDateOnly(value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString();
+  }
+  // Not date-only (a full timestamp) — render just the date portion of it.
+  return new Date(value).toLocaleDateString();
+}
+
+/**
  * Build the machine-readable projection of a task for `structuredContent`.
  *
  * Timestamps are passed through as the raw ISO 8601 strings Motion returns —
@@ -287,7 +305,7 @@ export function formatTaskDetail(task: MotionTask): CallToolResult {
       : null,
     task.duration ? `Duration: ${typeof task.duration === 'number' ? `${task.duration} minutes` : task.duration}` : null,
     task.deadlineType ? `Deadline Type: ${task.deadlineType}` : null,
-    task.startOn ? `Start On: ${new Date(task.startOn).toLocaleString()}` : null,
+    task.startOn ? `Start On: ${formatDateOnly(task.startOn)}` : null,
     task.scheduledStart ? `Scheduled Start: ${new Date(task.scheduledStart).toLocaleString()}` : null,
     task.scheduledEnd ? `Scheduled End: ${new Date(task.scheduledEnd).toLocaleString()}` : null,
     // The single most important signal for at-risk detection: unschedulable tasks

--- a/tests/response-formatters.spec.ts
+++ b/tests/response-formatters.spec.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from 'vitest';
-import { formatCustomFieldSuccess, formatDetailResponse } from '../src/utils';
+import { formatCustomFieldSuccess, formatDetailResponse, formatTaskDetail, formatTaskList } from '../src/utils';
+import type { MotionTask } from '../src/types/motion';
+
+// Minimal MotionTask factory — override only the fields a test cares about.
+function makeTask(overrides: Partial<MotionTask> = {}): MotionTask {
+  return {
+    id: 'task_1',
+    name: 'Test Task',
+    workspaceId: 'ws_1',
+    status: { name: 'Todo', isDefaultStatus: true, isResolvedStatus: false },
+    priority: 'MEDIUM',
+    labels: [],
+    completed: false,
+    createdTime: '2026-08-01T00:00:00.000Z',
+    workspace: { id: 'ws_1', name: 'Work', teamId: null, type: 'INDIVIDUAL' },
+    ...overrides
+  } as MotionTask;
+}
 
 describe('responseFormatters', () => {
   it('formats detail response with all fields when field list is omitted', () => {
@@ -24,5 +41,98 @@ describe('responseFormatters', () => {
 
     expect(text).not.toContain('remove_from_undefined');
     expect(text).toContain('Value ID: val_1');
+  });
+
+  describe('formatTaskDetail scheduling fields', () => {
+    it('renders schedulingIssue and startOn in the text', () => {
+      const res = formatTaskDetail(makeTask({
+        startOn: '2026-08-10T00:00:00.000Z',
+        schedulingIssue: true
+      }));
+      const text = (res.content?.[0] as any)?.text || '';
+
+      expect(text).toContain('Start On:');
+      expect(text).toContain('Scheduling Issue: Yes');
+    });
+
+    it('lists each chunk with start and end times', () => {
+      const res = formatTaskDetail(makeTask({
+        chunks: [
+          { id: 'c1', duration: 30, scheduledStart: '2026-08-10T14:00:00.000Z', scheduledEnd: '2026-08-10T14:30:00.000Z', isFixed: false },
+          { id: 'c2', duration: 30, scheduledStart: '2026-08-11T09:00:00.000Z', scheduledEnd: '2026-08-11T09:30:00.000Z', isFixed: true }
+        ]
+      }));
+      const text = (res.content?.[0] as any)?.text || '';
+
+      expect(text).toContain('Scheduled Chunks: 2 time block(s)');
+      expect(text).toContain('Chunk 1:');
+      expect(text).toContain('Chunk 2:');
+      expect(text).toContain('(fixed)');
+    });
+
+    it('attaches structuredContent with the expected keys and raw ISO timestamps', () => {
+      const res = formatTaskDetail(makeTask({
+        dueDate: '2026-08-15T17:00:00.000Z',
+        deadlineType: 'HARD',
+        duration: 60,
+        scheduledStart: '2026-08-14T14:00:00.000Z',
+        scheduledEnd: '2026-08-14T15:00:00.000Z',
+        startOn: '2026-08-10T00:00:00.000Z',
+        schedulingIssue: false,
+        labels: ['urgent', { name: 'q3' }]
+      }));
+      const sc = res.structuredContent as Record<string, any>;
+
+      expect(sc).toBeDefined();
+      for (const key of ['id', 'name', 'dueDate', 'deadlineType', 'duration',
+        'scheduledStart', 'scheduledEnd', 'schedulingIssue', 'startOn', 'labels', 'chunks']) {
+        expect(sc).toHaveProperty(key);
+      }
+      // Timestamps are passed through raw (ISO 8601), not localized
+      expect(sc.dueDate).toBe('2026-08-15T17:00:00.000Z');
+      expect(sc.scheduledEnd).toBe('2026-08-14T15:00:00.000Z');
+      // Labels normalized to plain strings regardless of source shape
+      expect(sc.labels).toEqual(['urgent', 'q3']);
+      expect(sc.schedulingIssue).toBe(false);
+    });
+
+    it('surfaces schedulingIssue: true for a task Motion could not fit (no scheduledEnd)', () => {
+      const res = formatTaskDetail(makeTask({
+        dueDate: '2026-08-15T17:00:00.000Z',
+        schedulingIssue: true
+        // no scheduledStart / scheduledEnd — the unschedulable case
+      }));
+      const sc = res.structuredContent as Record<string, any>;
+
+      expect(sc.schedulingIssue).toBe(true);
+      expect(sc.scheduledEnd).toBeNull();
+    });
+  });
+
+  describe('formatTaskList scheduling fields', () => {
+    it('includes scheduledEnd, startOn, and a scheduling-issue marker per line', () => {
+      const res = formatTaskList([
+        makeTask({ id: 't1', name: 'Fits', scheduledEnd: '2026-08-14T15:00:00.000Z', startOn: '2026-08-10T00:00:00.000Z' }),
+        makeTask({ id: 't2', name: 'Cannot fit', schedulingIssue: true })
+      ]);
+      const text = (res.content?.[0] as any)?.text || '';
+
+      expect(text).toContain('Scheduled End:');
+      expect(text).toContain('Start On:');
+      expect(text).toContain('[SCHEDULING ISSUE]');
+    });
+
+    it('attaches structuredContent with count and a per-task projection', () => {
+      const res = formatTaskList([
+        makeTask({ id: 't1', name: 'A' }),
+        makeTask({ id: 't2', name: 'B', schedulingIssue: true })
+      ]);
+      const sc = res.structuredContent as Record<string, any>;
+
+      expect(sc.count).toBe(2);
+      expect(Array.isArray(sc.tasks)).toBe(true);
+      expect(sc.tasks[0].id).toBe('t1');
+      expect(sc.tasks[1].schedulingIssue).toBe(true);
+    });
   });
 });

--- a/tests/response-formatters.spec.ts
+++ b/tests/response-formatters.spec.ts
@@ -96,6 +96,35 @@ describe('responseFormatters', () => {
       expect(sc.schedulingIssue).toBe(false);
     });
 
+    it('keeps the channels separate: readable text in content, fields in structuredContent', () => {
+      const res = formatTaskDetail(makeTask({ name: 'Readable Task', schedulingIssue: true }));
+      const text = (res.content?.[0] as any)?.text || '';
+      const sc = res.structuredContent as Record<string, any>;
+
+      // content is a plain-text block, not JSON
+      expect(text).toContain('Task: Readable Task');
+      expect(text).toContain('Scheduling Issue: Yes');
+      // structuredContent holds the fields — and does NOT duplicate the prose
+      expect(sc.summary).toBeUndefined();
+      expect(sc.schedulingIssue).toBe(true);
+      expect(sc.id).toBe('task_1');
+    });
+
+    it('renders startOn as a plain date, not a timezone-shifted timestamp', () => {
+      const res = formatTaskDetail(makeTask({ startOn: '2026-08-31' }));
+      const text = (res.content?.[0] as any)?.text || '';
+      const startOnLine = text.split('\n').find((l: string) => l.startsWith('Start On:'));
+
+      // Built from date parts, so the calendar day survives in zones behind UTC
+      // (naive `new Date("2026-08-31")` would render as Aug 30, 8:00 PM in US Eastern).
+      const expected = new Date(2026, 7, 31).toLocaleDateString();
+      expect(startOnLine).toBe(`Start On: ${expected}`);
+      // No time-of-day component
+      expect(startOnLine).not.toMatch(/\d:\d\d/);
+      // structuredContent still carries the raw ISO value
+      expect((res.structuredContent as any).startOn).toBe('2026-08-31');
+    });
+
     it('surfaces schedulingIssue: true for a task Motion could not fit (no scheduledEnd)', () => {
       const res = formatTaskDetail(makeTask({
         dueDate: '2026-08-15T17:00:00.000Z',
@@ -133,6 +162,22 @@ describe('responseFormatters', () => {
       expect(Array.isArray(sc.tasks)).toBe(true);
       expect(sc.tasks[0].id).toBe('t1');
       expect(sc.tasks[1].schedulingIssue).toBe(true);
+    });
+
+    it('stays lean — no prose duplicated into structuredContent', () => {
+      const res = formatTaskList([makeTask({ id: 't1' }), makeTask({ id: 't2' })]);
+      const sc = res.structuredContent as Record<string, any>;
+
+      expect(sc.summary).toBeUndefined();
+      expect(sc.tasks[0].summary).toBeUndefined();
+    });
+
+    it('renders startOn as a plain date in list lines too', () => {
+      const res = formatTaskList([makeTask({ id: 't1', startOn: '2026-08-31' })]);
+      const text = (res.content?.[0] as any)?.text || '';
+
+      const expected = new Date(2026, 7, 31).toLocaleDateString();
+      expect(text).toContain(`(Start On: ${expected})`);
     });
   });
 });


### PR DESCRIPTION
## Summary

The task formatters drop several scheduling fields, so a "how many hours behind am I" / at-risk report can't compute the at-risk half from the connector alone. This passes those fields through.

## What this changes

- `formatTaskDetail`: adds schedulingIssue, startOn, and per-chunk start/end times.
- `formatTaskList`: adds scheduledEnd, startOn, and a scheduling-issue marker per line.
- `formatMcpSuccess`: optional structuredContent arg; other callers unaffected.
- Both task formatters attach structuredContent with raw ISO 8601 timestamps.
- Out of scope: task dependencies/blockers (not in Motion's public API).

## Verification

- build, worker type-check, and tests all pass (458 tests; 6 new).
- New unit tests cover the text lines, structuredContent keys, and the unschedulable case.
- Manual live check against the real API confirmed both responses populate structuredContent.