### PR TITLE
fix: bump @cloudflare/workers-types to v5 to match wrangler peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "motionmcp": "dist/mcp-server.js"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250214.0",
+        "@cloudflare/workers-types": "^5.20260821.1",
         "@types/node": "^24.2.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
@@ -512,10 +512,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260219.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260219.0.tgz",
-      "integrity": "sha512-jL2BNnDqbKXDrxhtKx+wVmQpv/P6w8J4WVFiuT9OMEPsw8V2TfTozoWTcCZ2AhE09yK406xQFE4mBq9IIgobuw==",
-      "dev": true,
+      "version": "5.20260821.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260821.1.tgz",
+      "integrity": "sha512-jZiTISghTPeytJ7eDt5K1AV7df998xGECMgT8oy838VfFLJLROvdLzDaJb0/Jv4WfxO00keNoWt1d6olL7URRg==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2345,13 +2344,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/agents/node_modules/@cloudflare/workers-types": {
-      "version": "5.20260821.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260821.1.tgz",
-      "integrity": "sha512-jZiTISghTPeytJ7eDt5K1AV7df998xGECMgT8oy838VfFLJLROvdLzDaJb0/Jv4WfxO00keNoWt1d6olL7URRg==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
     },
     "node_modules/agents/node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
+    "@cloudflare/workers-types": "^5.20260821.1",
     "@types/node": "^24.2.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",


### PR DESCRIPTION
## Summary
- `npm install` on main currently fails with an ERESOLVE conflict: wrangler 4.125.0 (merged in #123) requires `@cloudflare/workers-types` `^5.20260820.1` as a peer dependency, but `package.json` still pinned `^4.20250214.0`.
- Bumps the devDependency to `^5.20260821.1` (latest, satisfies the peer range) and updates the lockfile.

## Test plan
- [x] `npm install` completes with no ERESOLVE errors
- [x] `npm run build` passes
- [x] `npm run worker:type-check` passes
- [x] `npm test` (452 tests) passes