### PR TITLE
feat: surface scheduling fields and structuredContent in task responses

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -194,10 +194,12 @@ export function formatMcpError(error: Error | unknown): CallToolResult {
 }
 
 /**
- * Format a success response for MCP protocol
+ * Format a success response for MCP protocol.
+ * When structuredContent is provided it is attached to the result so that
+ * machine consumers can index raw fields without parsing the prose text.
  */
-export function formatMcpSuccess(text: string): CallToolResult {
-  return {
+export function formatMcpSuccess(text: string, structuredContent?: Record<string, unknown>): CallToolResult {
+  const result: CallToolResult = {
     content: [
       {
         type: MCP_RESPONSE_TYPES.TEXT,
@@ -205,6 +207,10 @@ export function formatMcpSuccess(text: string): CallToolResult {
       }
     ]
   };
+  if (structuredContent !== undefined) {
+    result.structuredContent = structuredContent;
+  }
+  return result;
 }
 
 // ─── User-Facing Error Factories ────────────────────────────────────────────

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -134,9 +134,18 @@ export function formatTaskList(
     if (task.dueDate) {
       line += ` (Due: ${formatDateOnly(task.dueDate, timeZone)})`;
     }
+    if (task.startOn) {
+      line += ` (Start: ${formatDateOnly(task.startOn, timeZone)})`;
+    }
+    if (task.scheduledEnd) {
+      line += ` (Scheduled End: ${formatDateOnly(task.scheduledEnd, timeZone)})`;
+    }
+    if (task.schedulingIssue) {
+      line += ` [SCHEDULING ISSUE]`;
+    }
     return line;
   };
-  
+
   let title = `Found ${tasks.length} ${tasks.length === 1 ? 'task' : 'tasks'}`;
   if (allWorkspaces) {
     title += ` across all workspaces`;
@@ -160,7 +169,11 @@ export function formatTaskList(
   let responseText = `${title}:\n${list}`;
   responseText += formatTruncationNotice(truncation);
 
-  return formatMcpSuccess(responseText);
+  const structured: Record<string, unknown> = {
+    tasks: tasks.map(taskToStructuredContent),
+  };
+
+  return formatMcpSuccess(responseText, structured);
 }
 
 /**
@@ -213,6 +226,41 @@ export function formatDetailResponse<T extends Record<string, any>>(
 }
 
 /**
+ * Project a task into a flat object carrying raw ISO 8601 timestamps so that
+ * machine consumers (dashboards, at-risk math) can index fields directly
+ * without parsing the prose text.
+ */
+export function taskToStructuredContent(task: MotionTask): Record<string, unknown> {
+  return {
+    id: task.id,
+    name: task.name,
+    status: typeof task.status === 'string' ? task.status : task.status?.name ?? null,
+    priority: task.priority ?? null,
+    completed: task.completed,
+    dueDate: task.dueDate ?? null,
+    startOn: task.startOn ?? null,
+    scheduledStart: task.scheduledStart ?? null,
+    scheduledEnd: task.scheduledEnd ?? null,
+    schedulingIssue: task.schedulingIssue ?? null,
+    createdTime: task.createdTime ?? null,
+    updatedTime: task.updatedTime ?? null,
+    completedTime: task.completedTime ?? null,
+    workspaceId: task.workspace?.id ?? null,
+    projectId: task.project?.id ?? null,
+    chunks: task.chunks
+      ? task.chunks.map(c => ({
+          id: c.id ?? null,
+          duration: c.duration ?? null,
+          scheduledStart: c.scheduledStart ?? null,
+          scheduledEnd: c.scheduledEnd ?? null,
+          completedTime: c.completedTime ?? null,
+          isFixed: c.isFixed ?? null,
+        }))
+      : [],
+  };
+}
+
+/**
  * Format single task detail response with comprehensive information
  */
 export function formatTaskDetail(task: MotionTask, timeZone?: string): CallToolResult {
@@ -224,6 +272,8 @@ export function formatTaskDetail(task: MotionTask, timeZone?: string): CallToolR
     `Priority: ${task.priority || 'Not set'}`,
     `Completed: ${task.completed ? 'Yes' : 'No'}`,
     task.dueDate ? `Due Date: ${formatTimestamp(task.dueDate, timeZone)}` : 'Due Date: Not set',
+    task.startOn ? `Start On: ${formatDateOnly(task.startOn, timeZone)}` : null,
+    task.schedulingIssue ? `Scheduling Issue: Yes` : null,
     task.createdTime ? `Created: ${formatTimestamp(task.createdTime, timeZone)}` : null,
     task.updatedTime ? `Last Updated: ${formatTimestamp(task.updatedTime, timeZone)}` : null,
     task.completedTime ? `Completed: ${formatTimestamp(task.completedTime, timeZone)}` : null,
@@ -242,7 +292,9 @@ export function formatTaskDetail(task: MotionTask, timeZone?: string): CallToolR
     task.scheduledEnd ? `Scheduled End: ${formatTimestamp(task.scheduledEnd, timeZone)}` : null,
     task.parentRecurringTaskId ? `Recurring Task ID: ${task.parentRecurringTaskId}` : null,
     task.chunks && task.chunks.length > 0
-      ? `Scheduled Chunks: ${task.chunks.length} time block(s)`
+      ? `Scheduled Chunks (${task.chunks.length}):\n${task.chunks.map((c, i) =>
+          `  ${i + 1}. ${formatTimestamp(c.scheduledStart, timeZone)} - ${formatTimestamp(c.scheduledEnd, timeZone)} (${c.duration} min${c.isFixed ? ', fixed' : ''})`
+        ).join('\n')}`
       : null,
     task.customFieldValues && Object.keys(task.customFieldValues).length > 0
       ? `Custom Fields:\n${Object.entries(task.customFieldValues).map(([valueId, cfv]) =>
@@ -251,7 +303,7 @@ export function formatTaskDetail(task: MotionTask, timeZone?: string): CallToolR
       : null
   ].filter(Boolean).join('\n');
 
-  return formatMcpSuccess(details);
+  return formatMcpSuccess(details, taskToStructuredContent(task));
 }
 
 interface SearchOptions {

--- a/tests/response-formatters.spec.ts
+++ b/tests/response-formatters.spec.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { formatCustomFieldSuccess, formatDetailResponse } from '../src/utils';
+import { formatCustomFieldSuccess, formatDetailResponse, formatTaskDetail, formatTaskList, taskToStructuredContent } from '../src/utils';
+import { formatMcpSuccess } from '../src/utils/errors';
+import { MotionTask } from '../src/types/motion';
+
+function makeTask(overrides: Partial<MotionTask> = {}): MotionTask {
+  return {
+    id: 'task-1',
+    name: 'Test Task',
+    workspaceId: 'ws-1',
+    status: { name: 'In Progress', isDefaultStatus: false, isResolvedStatus: false },
+    priority: 'HIGH',
+    completed: false,
+    createdTime: '2026-08-10T14:00:00.000Z',
+    labels: [],
+    workspace: { id: 'ws-1', name: 'My Workspace', teamId: null, type: 'TEAM' },
+    ...overrides,
+  };
+}
+
+function textOf(result: ReturnType<typeof formatMcpSuccess>): string {
+  return (result.content?.[0] as any)?.text || '';
+}
 
 describe('responseFormatters', () => {
   it('formats detail response with all fields when field list is omitted', () => {
@@ -7,7 +28,7 @@ describe('responseFormatters', () => {
       { id: 'p1', name: 'Project A', workspaceId: 'w1' },
       'Project details for "Project A"'
     );
-    const text = (res.content?.[0] as any)?.text || '';
+    const text = textOf(res);
 
     expect(text).toContain('- Id: p1');
     expect(text).toContain('- Name: Project A');
@@ -20,9 +41,192 @@ describe('responseFormatters', () => {
       type: 'text',
       value: 'hello'
     });
-    const text = (res.content?.[0] as any)?.text || '';
+    const text = textOf(res);
 
     expect(text).not.toContain('remove_from_undefined');
     expect(text).toContain('Value ID: val_1');
+  });
+});
+
+describe('formatMcpSuccess', () => {
+  it('returns text-only result when structuredContent is omitted', () => {
+    const result = formatMcpSuccess('hello');
+    expect(textOf(result)).toBe('hello');
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it('attaches structuredContent when provided', () => {
+    const sc = { foo: 'bar', n: 42 };
+    const result = formatMcpSuccess('hello', sc);
+    expect(textOf(result)).toBe('hello');
+    expect(result.structuredContent).toEqual(sc);
+  });
+});
+
+describe('taskToStructuredContent', () => {
+  it('carries raw ISO timestamps without formatting', () => {
+    const task = makeTask({
+      dueDate: '2026-08-15T23:59:00.000Z',
+      startOn: '2026-08-11',
+      scheduledStart: '2026-08-12T09:00:00.000Z',
+      scheduledEnd: '2026-08-12T10:30:00.000Z',
+      schedulingIssue: false,
+    });
+
+    const sc = taskToStructuredContent(task);
+    expect(sc.id).toBe('task-1');
+    expect(sc.dueDate).toBe('2026-08-15T23:59:00.000Z');
+    expect(sc.startOn).toBe('2026-08-11');
+    expect(sc.scheduledStart).toBe('2026-08-12T09:00:00.000Z');
+    expect(sc.scheduledEnd).toBe('2026-08-12T10:30:00.000Z');
+    expect(sc.schedulingIssue).toBe(false);
+  });
+
+  it('nullifies absent optional fields', () => {
+    const task = makeTask();
+    const sc = taskToStructuredContent(task);
+    expect(sc.dueDate).toBeNull();
+    expect(sc.startOn).toBeNull();
+    expect(sc.scheduledStart).toBeNull();
+    expect(sc.scheduledEnd).toBeNull();
+    expect(sc.schedulingIssue).toBeNull();
+    expect(sc.completedTime).toBeNull();
+    expect(sc.chunks).toEqual([]);
+  });
+
+  it('projects chunks with ?? null for stable serialization', () => {
+    const task = makeTask({
+      chunks: [
+        { id: 'c1', duration: 30, scheduledStart: '2026-08-12T09:00:00.000Z', scheduledEnd: '2026-08-12T09:30:00.000Z', isFixed: false },
+        { id: 'c2', duration: 60, scheduledStart: '2026-08-13T14:00:00.000Z', scheduledEnd: '2026-08-13T15:00:00.000Z', completedTime: '2026-08-13T14:45:00.000Z', isFixed: true },
+      ],
+    });
+
+    const sc = taskToStructuredContent(task);
+    const chunks = sc.chunks as any[];
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].completedTime).toBeNull();
+    expect(chunks[1].completedTime).toBe('2026-08-13T14:45:00.000Z');
+    expect(chunks[1].isFixed).toBe(true);
+  });
+});
+
+describe('formatTaskDetail', () => {
+  it('includes startOn in text output (zone-aware)', () => {
+    const task = makeTask({ startOn: '2026-08-11T00:00:00.000Z' });
+    const text = textOf(formatTaskDetail(task, 'America/New_York'));
+    expect(text).toContain('Start On:');
+    expect(text).toContain('America/New_York');
+  });
+
+  it('includes scheduling issue marker', () => {
+    const task = makeTask({ schedulingIssue: true });
+    const text = textOf(formatTaskDetail(task));
+    expect(text).toContain('Scheduling Issue: Yes');
+  });
+
+  it('omits scheduling issue line when false or absent', () => {
+    expect(textOf(formatTaskDetail(makeTask({ schedulingIssue: false })))).not.toContain('Scheduling Issue');
+    expect(textOf(formatTaskDetail(makeTask()))).not.toContain('Scheduling Issue');
+  });
+
+  it('renders per-chunk start/end times with zone', () => {
+    const task = makeTask({
+      chunks: [
+        { id: 'c1', duration: 30, scheduledStart: '2026-08-12T13:00:00.000Z', scheduledEnd: '2026-08-12T13:30:00.000Z', isFixed: false },
+        { id: 'c2', duration: 60, scheduledStart: '2026-08-13T18:00:00.000Z', scheduledEnd: '2026-08-13T19:00:00.000Z', isFixed: true },
+      ],
+    });
+    const text = textOf(formatTaskDetail(task, 'America/New_York'));
+    expect(text).toContain('Scheduled Chunks (2):');
+    expect(text).toContain('30 min');
+    expect(text).toContain('60 min, fixed');
+    expect(text).toContain('America/New_York');
+  });
+
+  it('attaches structuredContent with raw ISO timestamps', () => {
+    const task = makeTask({
+      dueDate: '2026-08-15T23:59:00.000Z',
+      startOn: '2026-08-11',
+      scheduledStart: '2026-08-12T09:00:00.000Z',
+      scheduledEnd: '2026-08-12T10:30:00.000Z',
+    });
+    const result = formatTaskDetail(task, 'Asia/Kolkata');
+    expect(result.structuredContent).toBeDefined();
+    expect(result.structuredContent!.id).toBe('task-1');
+    expect(result.structuredContent!.dueDate).toBe('2026-08-15T23:59:00.000Z');
+    expect(result.structuredContent!.startOn).toBe('2026-08-11');
+  });
+
+  it('uses dateFormat.ts formatters, not toLocaleString', () => {
+    const task = makeTask({
+      dueDate: '2026-08-10T23:59:59.000Z',
+      startOn: '2026-08-11T00:00:00.000Z',
+    });
+    const text = textOf(formatTaskDetail(task, 'Asia/Kolkata'));
+    expect(text).not.toMatch(/\d{1,2}\/\d{1,2}\/\d{4},\s+\d{1,2}:\d{2}:\d{2}\s*(AM|PM)/);
+    expect(text).toContain('Asia/Kolkata');
+  });
+
+  it('handles unschedulable task (schedulingIssue: true, no chunks, no scheduledStart)', () => {
+    const task = makeTask({
+      schedulingIssue: true,
+      scheduledStart: undefined,
+      scheduledEnd: undefined,
+      chunks: undefined,
+    });
+    const text = textOf(formatTaskDetail(task));
+    expect(text).toContain('Scheduling Issue: Yes');
+    expect(text).not.toContain('Scheduled Start');
+    expect(text).not.toContain('Scheduled End');
+    expect(text).not.toContain('Scheduled Chunks');
+  });
+});
+
+describe('formatTaskList', () => {
+  it('includes startOn per task line', () => {
+    const tasks = [makeTask({ startOn: '2026-08-11T00:00:00.000Z' })];
+    const text = textOf(formatTaskList(tasks, { timeZone: 'America/New_York' }));
+    expect(text).toContain('(Start:');
+    expect(text).toContain('America/New_York');
+  });
+
+  it('includes scheduledEnd per task line', () => {
+    const tasks = [makeTask({ scheduledEnd: '2026-08-12T17:00:00.000Z' })];
+    const text = textOf(formatTaskList(tasks, { timeZone: 'America/New_York' }));
+    expect(text).toContain('(Scheduled End:');
+  });
+
+  it('shows [SCHEDULING ISSUE] marker for unschedulable tasks', () => {
+    const tasks = [makeTask({ schedulingIssue: true })];
+    const text = textOf(formatTaskList(tasks));
+    expect(text).toContain('[SCHEDULING ISSUE]');
+  });
+
+  it('omits scheduling issue marker when false', () => {
+    const tasks = [makeTask({ schedulingIssue: false })];
+    const text = textOf(formatTaskList(tasks));
+    expect(text).not.toContain('[SCHEDULING ISSUE]');
+  });
+
+  it('attaches structuredContent with tasks array', () => {
+    const tasks = [
+      makeTask({ id: 't1', startOn: '2026-08-11' }),
+      makeTask({ id: 't2', schedulingIssue: true }),
+    ];
+    const result = formatTaskList(tasks);
+    expect(result.structuredContent).toBeDefined();
+    const scTasks = result.structuredContent!.tasks as any[];
+    expect(scTasks).toHaveLength(2);
+    expect(scTasks[0].id).toBe('t1');
+    expect(scTasks[0].startOn).toBe('2026-08-11');
+    expect(scTasks[1].id).toBe('t2');
+    expect(scTasks[1].schedulingIssue).toBe(true);
+  });
+
+  it('uses dateFormat.ts formatters, not toLocaleString', () => {
+    const tasks = [makeTask({ dueDate: '2026-08-10T23:59:59.000Z' })];
+    const text = textOf(formatTaskList(tasks, { timeZone: 'Asia/Kolkata' }));
+    expect(text).not.toMatch(/\d{1,2}\/\d{1,2}\/\d{4},\s+\d{1,2}:\d{2}:\d{2}\s*(AM|PM)/);
   });
 });


### PR DESCRIPTION
## Summary

Closes #129. Reimplements the feature from #114 against current `main`, using the timezone-safe `dateFormat.ts` utilities.

- **`formatMcpSuccess`**: accepts optional `structuredContent` parameter (backward-compatible, existing callers unaffected)
- **`formatTaskDetail`**: adds `startOn`, `schedulingIssue`, and per-chunk start/end times to the text output, all zone-aware
- **`formatTaskList`**: adds `scheduledEnd`, `startOn`, and a `[SCHEDULING ISSUE]` marker per task line, all zone-aware
- **`taskToStructuredContent`**: new projection function that carries raw ISO 8601 timestamps so machine consumers (dashboards, at-risk math) can index fields directly without parsing prose
- All timestamps use `formatTimestamp`/`formatDateOnly` from `dateFormat.ts`, never `toLocaleString()`

## Test plan

- [x] 18 new tests covering all new formatter fields, structuredContent attachment, unschedulable-task case, and locale-independence assertions
- [x] All 496 tests pass (478 existing + 18 new)
- [x] `npm run build` passes
- [x] `npm run worker:type-check` passes
- [x] No `toLocaleString()`/`toLocaleDateString()` patterns in test assertions (verified via regex)

https://claude.ai/code/session_013iiMzStia6np5EY5Ek2LTY