### PR TITLE
fix(tasks): apply name filter client-side to prevent API hang

### DIFF
--- a/src/services/api/tasks.ts
+++ b/src/services/api/tasks.ts
@@ -63,9 +63,16 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
       maxPages
     });
 
-    // Client-side filters for params not supported by the API
+    // Client-side filters — applied after fetch because the Motion API either
+    // doesn't support these as query params (priority, dueDate) or because
+    // sending them server-side can hang for certain parameter combinations (name
+    // combined with projectId + includeAllStatuses causes the API to never respond).
     const applyClientFilters = (tasks: MotionTask[]): MotionTask[] => {
       let filtered = tasks;
+      if (name) {
+        const lowerName = name.toLowerCase();
+        filtered = filtered.filter(t => t.name?.toLowerCase().includes(lowerName));
+      }
       if (priority) {
         filtered = filtered.filter(t => t.priority === priority);
       }
@@ -110,10 +117,7 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
       if (assigneeId) {
         params.append('assigneeId', assigneeId);
       }
-      // Note: priority and dueDate are NOT valid API query params — filtered client-side after fetch
-      if (name) {
-        params.append('name', name);
-      }
+      // Note: name, priority, and dueDate are filtered client-side after fetch
       if (labels && labels.length > 0) {
         // API accepts 'label' (singular) as a string parameter
         for (const label of labels) {
@@ -136,7 +140,7 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
       // When client-side filters are active, don't cap pagination with maxItems
       // because valid matches may exist beyond the first batch. Fetch all pages
       // and apply the limit after filtering instead.
-      const hasClientFilters = Boolean(priority || dueDate);
+      const hasClientFilters = Boolean(name || priority || dueDate);
       const paginatedResult = await fetchAllPagesNew<MotionTask>(fetchPage, 'tasks', {
         maxPages,
         logProgress: false,  // Less verbose for tasks

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -121,7 +121,7 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       name: {
         type: "string",
-        description: "Task name (required for create, optional for list as case-insensitive substring search)"
+        description: "Task name (required for create, optional for list as case-insensitive substring search, filtered client-side)"
       },
       description: {
         type: "string",

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -41,7 +41,7 @@ export interface TruncationInfo {
   returnedCount: number;
   reason?: 'page_size_limit' | 'max_items' | 'max_pages' | 'error';
   limit?: number;
-  /** True when client-side filters (priority/dueDate) reduced the result set after pagination */
+  /** True when client-side filters (name/priority/dueDate) reduced the result set after pagination */
   clientFiltered?: boolean;
   /** Number of items fetched before client-side filtering was applied */
   fetchedCount?: number;

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -28,7 +28,7 @@ export function formatTruncationNotice(truncation?: TruncationInfo): string {
 
   // When client-side filtering reduced the result set after paginated fetching
   if (truncation.clientFiltered && truncation.fetchedCount) {
-    return `\n\nNote: Priority/due-date filtering was applied client-side after fetching ${truncation.fetchedCount} tasks (${TRUNCATION_REASON_MESSAGES[truncation.reason!] || 'due to pagination limits'}). ${truncation.returnedCount} tasks matched. There may be additional matching tasks on unfetched pages.`;
+    return `\n\nNote: Name/priority/due-date filtering was applied client-side after fetching ${truncation.fetchedCount} tasks (${TRUNCATION_REASON_MESSAGES[truncation.reason!] || 'due to pagination limits'}). ${truncation.returnedCount} tasks matched. There may be additional matching tasks on unfetched pages.`;
   }
 
   const reason = truncation.reason ? TRUNCATION_REASON_MESSAGES[truncation.reason] || '' : '';

--- a/tests/unit/tasks-name-filter.test.ts
+++ b/tests/unit/tasks-name-filter.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getTasks } from '../../src/services/api/tasks';
+import type { ResourceContext } from '../../src/services/api/types';
+
+function makeMockCtx(tasks: Array<{ id: string; name: string }>): ResourceContext {
+  const wrappedResponse = {
+    data: {
+      meta: { pageSize: 20 },
+      tasks,
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any,
+  };
+
+  return {
+    api: {
+      client: { get: vi.fn().mockResolvedValue(wrappedResponse) } as any,
+      requestWithRetry: vi.fn().mockImplementation((fn: () => any) => fn()),
+    } as any,
+    cache: {} as any,
+  };
+}
+
+describe('getTasks name filtering', () => {
+  const sampleTasks = [
+    { id: 't1', name: 'Deploy dashboard' },
+    { id: 't2', name: 'Fix login bug' },
+    { id: 't3', name: 'Dashboard redesign' },
+  ];
+
+  it('filters by name client-side (case-insensitive substring)', async () => {
+    const ctx = makeMockCtx(sampleTasks);
+    const result = await getTasks(ctx, { name: 'dashboard' });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((t: any) => t.id)).toEqual(['t1', 't3']);
+  });
+
+  it('does not send name as a query parameter to the API', async () => {
+    const ctx = makeMockCtx(sampleTasks);
+    await getTasks(ctx, { name: 'dashboard' });
+
+    const getCall = (ctx.api.client.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(getCall).not.toContain('name=');
+  });
+
+  it('handles projectId + name + includeAllStatuses without hanging', async () => {
+    const ctx = makeMockCtx(sampleTasks);
+    const result = await getTasks(ctx, {
+      projectId: 'p1',
+      name: 'dashboard',
+      includeAllStatuses: true,
+    });
+
+    expect(result.items).toHaveLength(2);
+    const getCall = (ctx.api.client.get as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(getCall).toContain('projectId=p1');
+    expect(getCall).toContain('includeAllStatuses=true');
+    expect(getCall).not.toContain('name=');
+  });
+
+  it('returns all tasks when no name filter is provided', async () => {
+    const ctx = makeMockCtx(sampleTasks);
+    const result = await getTasks(ctx, {});
+
+    expect(result.items).toHaveLength(3);
+  });
+
+  it('returns empty when name matches nothing', async () => {
+    const ctx = makeMockCtx(sampleTasks);
+    const result = await getTasks(ctx, { name: 'nonexistent' });
+
+    expect(result.items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Moves `name` filtering from a server-side API query parameter to client-side filtering, matching the existing pattern used for `priority` and `dueDate`
- The Motion API hangs indefinitely when `projectId`, `name`, and `includeAllStatuses` are all sent as query parameters together (each pairwise subset works fine)
- Client-side name filtering (case-insensitive substring match) avoids the buggy API combination while preserving correct results

Fixes #112

## Changes

- **`src/services/api/tasks.ts`**: Remove `name` from `fetchPage` query params; add name matching to `applyClientFilters`; include `name` in `hasClientFilters` so pagination fetches enough data before filtering
- **`src/tools/ToolDefinitions.ts`**: Update tool description to note client-side filtering
- **`src/types/mcp.ts`**, **`src/utils/responseFormatters.ts`**: Update comments and truncation notice to mention name filtering

## Test plan

- [x] New test file `tests/unit/tasks-name-filter.test.ts` with 5 tests covering: client-side name filtering, query param exclusion, the three-way parameter combination, no-filter passthrough, and no-match empty result
- [x] All 501 tests pass (496 existing + 5 new)
- [x] Both entry points type-check (`npm run build && npm run worker:type-check`)

https://claude.ai/code/session_01LAxDZZcuCScPjWcihrcQK2