### PR TITLE
chore(deps): bump @hono/node-server to 2.1.1 (GHSA-frvp-7c67-39w9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -958,12 +958,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"


### PR DESCRIPTION
Resolves Dependabot alert #149 (moderate, CWE-22 path traversal on Windows static file serving via `serve-static`).

## What

Bumps the transitive `@hono/node-server` from `1.19.13` (vulnerable, `< 1.19.15`) to `2.1.1` (patched). It's pulled in via `@modelcontextprotocol/sdk@1.30.0`, whose dependency range `^1.19.9 || ^2.0.5` allows the patched 2.x line, so `npm update` resolves to `2.1.1`. **Lockfile-only** — no `package.json` change, no `overrides` needed.

## Exposure

None in this project. MotionMCP never imports `@hono/node-server` or `serveStatic` and serves no static files:
- stdio entry point (`src/mcp-server.ts`) uses stdio transport — no HTTP server
- Worker entry point (`src/worker.ts`) runs on the Cloudflare Workers runtime, not Node, so the Node adapter is neither bundled nor executed

The advisory also requires a Windows host serving a static subtree behind prefix-mounted middleware. The bump is housekeeping to clear the alert, not a fix for a reachable issue here.

## Verification

`type-check`, `worker:type-check`, `build`, and `npm test` (501 passed) all clean.

https://claude.ai/code/session_01HbZLaLAKnrR3ZoZkZUk1Dn