### PR TITLE
fix: project duration, deadlineType, labels in taskToStructuredContent (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - **Validator mutated caller arguments**: AJV's `coerceTypes` rewrote the input object in place. Validation now runs against a clone, and handlers receive the coerced values. (#132)
 - **A duplicate name in `MOTION_MCP_TOOLS=custom:...` crashed Worker startup**: the custom tool list is de-duplicated. (#132)
 - **Empty select `options` were accepted** when creating a custom field, and recurring task `duration` was unvalidated. Both are now rejected, with matching schema constraints (`minItems: 1`, `minimum: 0`). (#132)
+- **`structuredContent` omitted fields the text output shows**: `taskToStructuredContent` now projects `duration`, `deadlineType`, and `labels`, so machine consumers see the same task fields human readers do. `duration` is projected directly rather than summed from `chunks`, which read `0` for exactly the unschedulable tasks (`schedulingIssue: true`, `chunks: []`) an at-risk report exists to surface. (#140)
 
 ### 🛠️ API Changes
 

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -247,6 +247,11 @@ export function taskToStructuredContent(task: MotionTask): Record<string, unknow
     completedTime: task.completedTime ?? null,
     workspaceId: task.workspace?.id ?? null,
     projectId: task.project?.id ?? null,
+    deadlineType: task.deadlineType ?? null,
+    duration: task.duration ?? null,
+    labels: Array.isArray(task.labels)
+      ? task.labels.map(l => (typeof l === 'string' ? l : l.name))
+      : [],
     chunks: task.chunks
       ? task.chunks.map(c => ({
           id: c.id ?? null,

--- a/tests/response-formatters.spec.ts
+++ b/tests/response-formatters.spec.ts
@@ -92,6 +92,9 @@ describe('taskToStructuredContent', () => {
     expect(sc.schedulingIssue).toBeNull();
     expect(sc.completedTime).toBeNull();
     expect(sc.chunks).toEqual([]);
+    expect(sc.deadlineType).toBeNull();
+    expect(sc.duration).toBeNull();
+    expect(sc.labels).toEqual([]);
   });
 
   it('projects chunks with ?? null for stable serialization', () => {
@@ -108,6 +111,27 @@ describe('taskToStructuredContent', () => {
     expect(chunks[0].completedTime).toBeNull();
     expect(chunks[1].completedTime).toBe('2026-08-13T14:45:00.000Z');
     expect(chunks[1].isFixed).toBe(true);
+  });
+
+  it('projects deadlineType and duration', () => {
+    const task = makeTask({ deadlineType: 'HARD', duration: 90 });
+    const sc = taskToStructuredContent(task);
+    expect(sc.deadlineType).toBe('HARD');
+    expect(sc.duration).toBe(90);
+  });
+
+  it('preserves duration when the task could not be scheduled (schedulingIssue with empty chunks)', () => {
+    const task = makeTask({ schedulingIssue: true, chunks: [], duration: 45 });
+    const sc = taskToStructuredContent(task);
+    expect(sc.schedulingIssue).toBe(true);
+    expect(sc.chunks).toEqual([]);
+    expect(sc.duration).toBe(45);
+  });
+
+  it('normalizes labels from both string and {name} object forms', () => {
+    const task = makeTask({ labels: ['urgent', { name: 'backend' }] });
+    const sc = taskToStructuredContent(task);
+    expect(sc.labels).toEqual(['urgent', 'backend']);
   });
 });
 


### PR DESCRIPTION
## Summary
`taskToStructuredContent` in `src/utils/responseFormatters.ts` omitted `duration`, `deadlineType`, and `labels`, even though the TEXT output of the same formatter renders Duration, Deadline Type, and Labels. Machine consumers of `structuredContent` lost fields human readers could see. This change adds those three fields (purely additive).

- `deadlineType`: `task.deadlineType ?? null`
- `duration`: `task.duration ?? null` (projected directly, not summed from `chunks` -- a task Motion could not schedule has `schedulingIssue: true` and `chunks: []` while still having a duration)
- `labels`: normalized to `string[]` the same way the text output does (`typeof l === 'string' ? l : l.name`), `[]` when absent

Tests extended in `tests/response-formatters.spec.ts`: null defaults, a `deadlineType`/`duration` case, a `schedulingIssue: true` + `chunks: []` case asserting duration is preserved, and label normalization from both string and `{name}` forms.

Verification (from worktree): `npx vitest run` (623 passed), `npx tsc --noEmit` (clean), `npx tsc --noEmit -p tsconfig.worker.json` (clean).

Closes #140

https://claude.ai/code/session_01DWEXxzwrqhGBrKLq68mDHd