### PR TITLE
fix: answer CORS preflight before the auth gate on /mcp routes (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - **Validator mutated caller arguments**: AJV's `coerceTypes` rewrote the input object in place. Validation now runs against a clone, and handlers receive the coerced values. (#132)
 - **A duplicate name in `MOTION_MCP_TOOLS=custom:...` crashed Worker startup**: the custom tool list is de-duplicated. (#132)
 - **Empty select `options` were accepted** when creating a custom field, and recurring task `duration` was unvalidated. Both are now rejected, with matching schema constraints (`minItems: 1`, `minimum: 0`). (#132)
+- **CORS preflight was rejected on `/mcp` (Bearer mode) and `/mcp/message`**: the auth gate answered `OPTIONS` with a 404, but browsers send preflights without credentials, so browser-origin MCP clients could not use Bearer mode or the legacy SSE message endpoint at all. Preflights under `/mcp` are now answered before the gate with the same CORS headers the agents SDK emits; every non-`OPTIONS` request stays fully gated. (#138)
 
 ### 🛠️ API Changes
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -101,6 +101,42 @@ export default {
 
     const pathParts = url.pathname.split("/").filter(Boolean);
 
+    // CORS preflight, answered BEFORE the auth gate below.
+    //
+    // A browser strips Authorization from a CORS preflight and announces the
+    // header it intends to send via Access-Control-Request-Headers instead, so
+    // an OPTIONS request under /mcp carries no credential the gate could accept.
+    // Left to the gate it 404s with no CORS headers, and the browser then blocks
+    // the real (credentialed) request that would follow. That made Bearer mode
+    // unusable from any browser-origin MCP client, and broke the legacy-SSE
+    // preflight on OPTIONS /mcp/message too (issue #138).
+    //
+    // These headers mirror the agents SDK's own corsHeaders()/handleCORS()
+    // exactly (agents/dist/mcp/index.js): a null body, the default 200 status,
+    // and the SDK's default header values. Allow-Headers therefore includes
+    // authorization and mcp-session-id, which is what a Bearer-mode client's
+    // preflight asks about. Kept in sync with the SDK so the answer a preflight
+    // gets here matches what it would get from the agent on any other method.
+    //
+    // Scoped to pathParts[0] === "mcp": only the MCP routes get an open
+    // preflight responder, not the whole Worker. The trade-off is that this
+    // reveals /mcp answers OPTIONS without a credential. That grants no access:
+    // a preflight carries none and returns no data, and every non-OPTIONS
+    // request still falls through to the auth gate unchanged. The point of the
+    // gate (a real request needs the secret) is preserved.
+    if (request.method === "OPTIONS" && pathParts[0] === "mcp") {
+      return new Response(null, {
+        headers: {
+          "Access-Control-Allow-Headers":
+            "Content-Type, Accept, Authorization, mcp-session-id, mcp-protocol-version",
+          "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "mcp-session-id",
+          "Access-Control-Max-Age": "86400",
+        },
+      });
+    }
+
     // Two authentication modes, both compared in constant time:
     //   1. Authorization: Bearer <secret> header (preferred; keeps the secret
     //      out of the URL for header-capable clients). The path is already

--- a/tests/worker/worker-auth.spec.ts
+++ b/tests/worker/worker-auth.spec.ts
@@ -136,6 +136,92 @@ describe("worker auth", () => {
     });
   });
 
+  describe("CORS preflight (issue #138)", () => {
+    // A browser strips Authorization from a preflight, so an OPTIONS under /mcp
+    // carries no credential. The Worker answers it before the auth gate, with
+    // the same CORS headers the agents SDK emits, so the real request that
+    // follows is allowed. The preflight itself never reaches the agent.
+
+    it("answers OPTIONS /mcp without auth, with CORS headers", async () => {
+      const response = await fetchWorker(
+        new Request("https://example.com/mcp", {
+          method: "OPTIONS",
+          headers: {
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization, content-type",
+          },
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(agentCalls).toHaveLength(0);
+
+      const allowHeaders = response.headers.get("Access-Control-Allow-Headers")!;
+      expect(allowHeaders.toLowerCase()).toContain("authorization");
+      expect(allowHeaders.toLowerCase()).toContain("mcp-session-id");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST, DELETE, OPTIONS");
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+    });
+
+    it("answers OPTIONS on the legacy SSE message endpoint (was 404)", async () => {
+      const response = await fetchWorker(
+        new Request("https://example.com/mcp/message?sessionId=abc", { method: "OPTIONS" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(
+        response.headers.get("Access-Control-Allow-Headers")!.toLowerCase()
+      ).toContain("authorization");
+      expect(agentCalls).toHaveLength(0);
+    });
+
+    it("answers OPTIONS /mcp/<secret> with CORS headers", async () => {
+      const response = await fetchWorker(
+        new Request(`https://example.com/mcp/${SECRET}`, { method: "OPTIONS" })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(agentCalls).toHaveLength(0);
+    });
+
+    it("does not answer OPTIONS outside /mcp", async () => {
+      // The preflight responder is scoped to /mcp; other paths fall through to
+      // the auth gate, which rejects a non-mcp prefix.
+      const response = await fetchWorker(
+        new Request("https://example.com/other", { method: "OPTIONS" })
+      );
+
+      expect(response.status).toBe(404);
+      expect(agentCalls).toHaveLength(0);
+    });
+
+    it("leaves non-OPTIONS auth unchanged: POST /mcp with no credential still 404s", async () => {
+      const response = await fetchWorker(
+        new Request("https://example.com/mcp", { method: "POST", body: "{}" })
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe("Not found");
+      expect(agentCalls).toHaveLength(0);
+    });
+
+    it("leaves the SSE message endpoint gated: POST with no secret still 404s", async () => {
+      const response = await fetchWorker(
+        new Request("https://example.com/mcp/message?sessionId=abc", {
+          method: "POST",
+          body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+        })
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe("Not found");
+      expect(agentCalls).toHaveLength(0);
+    });
+  });
+
   describe("secretsMatch", () => {
     it("accepts the correct secret", async () => {
       await expect(secretsMatch(SECRET, SECRET)).resolves.toBe(true);


### PR DESCRIPTION
## Summary

The Worker auth gate in `src/worker.ts` runs before any request reaches the agents SDK and rejected `OPTIONS` preflights with 404 and no CORS headers. Browsers strip `Authorization` from a CORS preflight (announcing the intended header via `Access-Control-Request-Headers`), so a preflight carries no credential the gate could accept. The browser then blocked the real credentialed request. This made Bearer mode unusable from any browser-origin MCP client and broke the legacy-SSE preflight on `OPTIONS /mcp/message`.

This answers `OPTIONS` preflights for paths under `/mcp` (`pathParts[0] === "mcp"`) **before** the auth gate, emitting the exact CORS header set the agents SDK's own `corsHeaders()`/`handleCORS()` produces (null body, 200 status, `Access-Control-Allow-Headers` including `authorization` and `mcp-session-id`).

## Routes fixed

- `OPTIONS /mcp` (preflight for Bearer-mode POST): was 404 -> now 200 with CORS headers.
- `OPTIONS /mcp/message?sessionId=...` (preflight for legacy SSE POST): was 404 -> now 200 with CORS headers.
- `OPTIONS /mcp/<secret>`: still returns CORS headers.

## Trade-off

Answering preflights unconditionally for `/mcp` reveals that `/mcp` responds to `OPTIONS` without a credential. That grants no access: a preflight carries none and returns no data, and every non-`OPTIONS` request still falls through to the auth gate unchanged. Regression tests assert `POST /mcp` and `POST /mcp/message` with no credential still 404.

## Verification

- `npx vitest run`: 626 passed (32 files)
- `npx vitest run --project worker`: 86 passed
- `npx tsc --noEmit -p tsconfig.worker.json`: clean
- `npx tsc --noEmit`: clean

Closes #138

https://claude.ai/code/session_01DWEXxzwrqhGBrKLq68mDHd