### PR TITLE
test: cover untested paths surfaced by the #132 review (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 
 - Added regression coverage for assignee resolution and workspace scoping, sanitize tag anchoring, frequency transforms, duration parsing, validator cloning/coercion, custom tool de-duplication, and status/search/custom-field/recurring handler paths. 539 tests across 30 files.
 - **Known gap**: `src/worker.ts` has no test coverage. `crypto.subtle.timingSafeEqual` is workerd-only and unavailable in the plain-Node Vitest setup, so covering the auth path needs `@cloudflare/vitest-pool-workers`. Tracked as follow-up work.
+- Covered four implemented-but-untested paths surfaced by the #132 review: `jsonSchemaToZodObject` strictness (rejects unknown keys; enforces `minLength`, `minimum: 0`, `minItems: 1`), `fetchAllPages` truncation (oversized-page stop without cursor advance, accurate `returnedCount`, `max_items` precedence, `max_pages` ceiling), the `workspaceResolver` ambiguous case-insensitive-match warning, and `endOfDayInZone` across DST transitions in both hemispheres plus a fixed-offset control. (#136)
 
 ## [2.8.0] - 2026-03-02
 

--- a/tests/dateFormat.dst.spec.ts
+++ b/tests/dateFormat.dst.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * DST-boundary coverage for endOfDayInZone (issue #136).
+ *
+ * endOfDayInZone returns the UTC instant of 23:59:59.000 local wall-clock on a
+ * given calendar date in a given IANA zone. The refined-offset step exists so a
+ * date whose end-of-day sits on the far side of a DST transition resolves to the
+ * offset actually in effect at 23:59:59 that day, not the offset guessed from a
+ * naive UTC anchor.
+ *
+ * The existing dateFormat.spec.ts covers a single non-DST date in IST and NY.
+ * This spec brackets both directions of the transition for a zone WEST of UTC
+ * (America/New_York) and a zone EAST of UTC (Australia/Sydney, southern
+ * hemisphere so the transitions run opposite), with America/Phoenix (UTC-7,
+ * no DST) as a fixed-offset control. Expected instants were computed from the
+ * zone offsets in effect at end-of-day on each date.
+ */
+import { describe, it, expect } from 'vitest';
+import { endOfDayInZone } from '../src/utils/dateFormat';
+
+describe('endOfDayInZone across DST boundaries', () => {
+  describe('America/New_York (west of UTC)', () => {
+    it('uses the pre-transition offset the day before spring-forward, post after', () => {
+      // Spring forward 2026-03-08: EST (UTC-5) -> EDT (UTC-4) at 02:00 local.
+      // Mar 7 ends in EST: 23:59:59 -05:00 = 04:59:59Z next day.
+      expect(endOfDayInZone('2026-03-07', 'America/New_York')).toBe('2026-03-08T04:59:59.000Z');
+      // Mar 8 ends in EDT: 23:59:59 -04:00 = 03:59:59Z next day.
+      expect(endOfDayInZone('2026-03-08', 'America/New_York')).toBe('2026-03-09T03:59:59.000Z');
+    });
+
+    it('uses the pre-transition offset the day before fall-back, post after', () => {
+      // Fall back 2026-11-01: EDT (UTC-4) -> EST (UTC-5) at 02:00 local.
+      // Oct 31 ends in EDT: 23:59:59 -04:00 = 03:59:59Z next day.
+      expect(endOfDayInZone('2026-10-31', 'America/New_York')).toBe('2026-11-01T03:59:59.000Z');
+      // Nov 1 ends in EST: 23:59:59 -05:00 = 04:59:59Z next day.
+      expect(endOfDayInZone('2026-11-01', 'America/New_York')).toBe('2026-11-02T04:59:59.000Z');
+    });
+  });
+
+  describe('Australia/Sydney (east of UTC, southern-hemisphere DST)', () => {
+    it('uses the pre-transition offset the day before fall-back, post after', () => {
+      // Fall back 2026-04-05: AEDT (UTC+11) -> AEST (UTC+10) at 03:00 local.
+      // Apr 4 ends in AEDT: 23:59:59 +11:00 = 12:59:59Z same day.
+      expect(endOfDayInZone('2026-04-04', 'Australia/Sydney')).toBe('2026-04-04T12:59:59.000Z');
+      // Apr 5 ends in AEST: 23:59:59 +10:00 = 13:59:59Z same day.
+      expect(endOfDayInZone('2026-04-05', 'Australia/Sydney')).toBe('2026-04-05T13:59:59.000Z');
+    });
+
+    it('uses the pre-transition offset the day before spring-forward, post after', () => {
+      // Spring forward 2026-10-04: AEST (UTC+10) -> AEDT (UTC+11) at 02:00 local.
+      // Oct 3 ends in AEST: 23:59:59 +10:00 = 13:59:59Z same day.
+      expect(endOfDayInZone('2026-10-03', 'Australia/Sydney')).toBe('2026-10-03T13:59:59.000Z');
+      // Oct 4 ends in AEDT: 23:59:59 +11:00 = 12:59:59Z same day.
+      expect(endOfDayInZone('2026-10-04', 'Australia/Sydney')).toBe('2026-10-04T12:59:59.000Z');
+    });
+  });
+
+  describe('America/Phoenix (fixed offset, control)', () => {
+    it('keeps the same UTC-7 offset across the DST calendar', () => {
+      // Arizona does not observe DST, so winter and summer end-of-day both use
+      // UTC-7: 23:59:59 -07:00 = 06:59:59Z next day.
+      expect(endOfDayInZone('2026-01-15', 'America/Phoenix')).toBe('2026-01-16T06:59:59.000Z');
+      expect(endOfDayInZone('2026-07-15', 'America/Phoenix')).toBe('2026-07-16T06:59:59.000Z');
+    });
+  });
+});

--- a/tests/jsonSchemaToZodObject.spec.ts
+++ b/tests/jsonSchemaToZodObject.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Node-side coverage for jsonSchemaToZodObject (issue #136).
+ *
+ * jsonSchemaToZodObject is pure zod and runs in Node, so this spec runs in the
+ * node project. It complements tests/worker/json-schema-to-zod.spec.ts, which
+ * already pins the additionalProperties: false / required / enum behaviour.
+ * Here the focus is the value-shape constraints the tool schemas rely on and
+ * that the worker spec does not assert: minLength on the task assignee fields,
+ * minimum: 0 on recurring-task duration, and minItems: 1 on custom-field
+ * options. These are the constraints the stdio AJV path enforces; this proves
+ * the converted Worker schema enforces them too.
+ */
+import { describe, it, expect } from 'vitest';
+import { jsonSchemaToZodObject } from '../src/utils/jsonSchemaToZod';
+import {
+  tasksToolDefinition,
+  recurringTasksToolDefinition,
+  customFieldsToolDefinition
+} from '../src/tools/ToolDefinitions';
+
+type SchemaInput = Parameters<typeof jsonSchemaToZodObject>[0];
+
+const tasksSchema = () => jsonSchemaToZodObject(tasksToolDefinition.inputSchema as SchemaInput);
+const recurringSchema = () =>
+  jsonSchemaToZodObject(recurringTasksToolDefinition.inputSchema as SchemaInput);
+const customFieldsSchema = () =>
+  jsonSchemaToZodObject(customFieldsToolDefinition.inputSchema as SchemaInput);
+
+describe('jsonSchemaToZodObject value constraints', () => {
+  describe('minLength on task assignee fields', () => {
+    it('rejects an empty assigneeId but accepts a non-empty one', () => {
+      const schema = tasksSchema();
+
+      expect(schema.safeParse({ operation: 'list', assigneeId: '' }).success).toBe(false);
+      expect(schema.safeParse({ operation: 'list', assigneeId: 'user-1' }).success).toBe(true);
+    });
+
+    it('rejects an empty assignee but accepts a non-empty one', () => {
+      const schema = tasksSchema();
+
+      expect(schema.safeParse({ operation: 'list', assignee: '' }).success).toBe(false);
+      expect(schema.safeParse({ operation: 'list', assignee: 'me' }).success).toBe(true);
+    });
+  });
+
+  describe('minimum: 0 on recurring-task duration', () => {
+    it('rejects a negative numeric duration', () => {
+      const schema = recurringSchema();
+
+      expect(schema.safeParse({ operation: 'create', duration: -5 }).success).toBe(false);
+    });
+
+    it('accepts zero and positive numeric durations', () => {
+      const schema = recurringSchema();
+
+      expect(schema.safeParse({ operation: 'create', duration: 0 }).success).toBe(true);
+      expect(schema.safeParse({ operation: 'create', duration: 30 }).success).toBe(true);
+    });
+
+    it('accepts the REMINDER string branch of the duration union', () => {
+      const schema = recurringSchema();
+
+      expect(schema.safeParse({ operation: 'create', duration: 'REMINDER' }).success).toBe(true);
+    });
+  });
+
+  describe('minItems: 1 on custom-field options', () => {
+    it('rejects an empty options array but accepts a populated one', () => {
+      const schema = customFieldsSchema();
+
+      expect(schema.safeParse({ operation: 'create', options: [] }).success).toBe(false);
+      expect(schema.safeParse({ operation: 'create', options: ['A'] }).success).toBe(true);
+    });
+  });
+});

--- a/tests/paginationTruncation.spec.ts
+++ b/tests/paginationTruncation.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Truncation coverage for fetchAllPages (issue #136).
+ *
+ * The existing tests/pagination.spec.ts covers happy-path accumulation and the
+ * cursor-not-advancing guard. This spec pins the three truncation reasons and
+ * the returnedCount they report:
+ *   - page_size_limit: a single oversized page is sliced to MAX_PAGE_SIZE and
+ *     pagination STOPS rather than advancing the cursor (which would silently
+ *     drop items 201+ of that page).
+ *   - max_items: the caller's item cap stops pagination, and takes precedence
+ *     over page_size_limit when both fire in the same iteration.
+ *   - max_pages: the page-count ceiling stops pagination.
+ *
+ * 'tasks' is a wrapped endpoint: unwrapApiResponse reads { meta, tasks }.
+ */
+import { describe, it, expect } from 'vitest';
+import { fetchAllPages } from '../src/utils/paginationNew';
+import { LIMITS } from '../src/utils/constants';
+
+function makeAxiosResponse(data: any) {
+  return { data } as any;
+}
+
+/** A wrapped Motion task page with an optional nextCursor. */
+function taskPage(count: number, nextCursor?: string) {
+  const tasks = Array.from({ length: count }, (_, i) => i);
+  return { meta: nextCursor ? { nextCursor } : {}, tasks };
+}
+
+describe('fetchAllPages truncation', () => {
+  it('stops on an oversized page instead of advancing the cursor, and reports the returned count', async () => {
+    // First page is larger than MAX_PAGE_SIZE and carries a nextCursor. The
+    // oversized page must be sliced and pagination must stop; the second page
+    // must never be fetched.
+    const fetched: Array<string | undefined> = [];
+    const pages: Record<string, any> = {
+      undefined: taskPage(LIMITS.MAX_PAGE_SIZE + 50, 'page-2'),
+      'page-2': taskPage(5)
+    };
+    const fetchPage = async (cursor?: string) => {
+      fetched.push(cursor);
+      return makeAxiosResponse(pages[String(cursor)]);
+    };
+
+    const res = await fetchAllPages<number>(fetchPage, 'tasks', { logProgress: false });
+
+    expect(res.items).toHaveLength(LIMITS.MAX_PAGE_SIZE);
+    expect(res.hasMore).toBe(false);
+    expect(fetched).toEqual([undefined]); // page-2 was never requested
+    expect(res.truncation).toEqual({
+      wasTruncated: true,
+      returnedCount: LIMITS.MAX_PAGE_SIZE,
+      reason: 'page_size_limit',
+      limit: LIMITS.MAX_PAGE_SIZE
+    });
+    // returnedCount reflects what was actually returned, not 0.
+    expect(res.truncation?.returnedCount).toBe(res.items.length);
+  });
+
+  it('stops at max_items and reports the returned count', async () => {
+    // Two full-size pages available; maxItems caps collection below one page.
+    const pages: Record<string, any> = {
+      undefined: taskPage(10, 'page-2'),
+      'page-2': taskPage(10)
+    };
+    const fetchPage = async (cursor?: string) => makeAxiosResponse(pages[String(cursor)]);
+
+    const res = await fetchAllPages<number>(fetchPage, 'tasks', {
+      logProgress: false,
+      maxItems: 4
+    });
+
+    expect(res.items).toHaveLength(4);
+    expect(res.hasMore).toBe(false);
+    expect(res.truncation).toEqual({
+      wasTruncated: true,
+      returnedCount: 4,
+      reason: 'max_items',
+      limit: 4
+    });
+  });
+
+  it('lets max_items take precedence over page_size_limit when both fire in one iteration', async () => {
+    // A single oversized page also exceeds maxItems. The slice trims to
+    // MAX_PAGE_SIZE, then the maxItems cap trims further; the recorded reason
+    // must be max_items, not page_size_limit.
+    const maxItems = LIMITS.MAX_PAGE_SIZE - 10;
+    const pages: Record<string, any> = {
+      undefined: taskPage(LIMITS.MAX_PAGE_SIZE + 50, 'page-2')
+    };
+    const fetchPage = async (cursor?: string) => makeAxiosResponse(pages[String(cursor)]);
+
+    const res = await fetchAllPages<number>(fetchPage, 'tasks', {
+      logProgress: false,
+      maxItems
+    });
+
+    expect(res.items).toHaveLength(maxItems);
+    expect(res.hasMore).toBe(false);
+    expect(res.truncation?.reason).toBe('max_items');
+    expect(res.truncation?.returnedCount).toBe(maxItems);
+    expect(res.truncation?.limit).toBe(maxItems);
+  });
+
+  it('stops at max_pages when every page keeps advancing the cursor', async () => {
+    // Each page hands back a fresh cursor forever; maxPages bounds the fetch.
+    const maxPages = 3;
+    let n = 0;
+    const fetchPage = async (_cursor?: string) => {
+      n += 1;
+      return makeAxiosResponse(taskPage(2, `cursor-${n}`));
+    };
+
+    const res = await fetchAllPages<number>(fetchPage, 'tasks', {
+      logProgress: false,
+      maxPages
+    });
+
+    expect(res.items).toHaveLength(maxPages * 2);
+    expect(res.hasMore).toBe(false);
+    expect(res.truncation).toEqual({
+      wasTruncated: true,
+      returnedCount: maxPages * 2,
+      reason: 'max_pages',
+      limit: maxPages
+    });
+  });
+
+  it('stops when the cursor does not advance, with no truncation record', async () => {
+    // Guard duplication of the existing spec, but assert the outcome shape:
+    // collected items are returned and no truncation reason is attached.
+    const pages: Record<string, any> = {
+      undefined: taskPage(2, 'stuck'),
+      stuck: { meta: { nextCursor: 'stuck' }, tasks: [9] }
+    };
+    const fetchPage = async (cursor?: string) => makeAxiosResponse(pages[String(cursor)]);
+
+    const res = await fetchAllPages<number>(fetchPage, 'tasks', { logProgress: false });
+
+    expect(res.items).toHaveLength(3);
+    expect(res.hasMore).toBe(false);
+    expect(res.truncation).toBeUndefined();
+  });
+});

--- a/tests/workspaceResolver.ambiguous.spec.ts
+++ b/tests/workspaceResolver.ambiguous.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Ambiguous case-insensitive match coverage for WorkspaceResolver (issue #136).
+ *
+ * When no exact name match exists and multiple workspaces differ only by case,
+ * resolveByWorkspaceName returns the FIRST case-insensitive match and logs a
+ * WARN. This pins both halves: the warning is emitted and the first match is
+ * still returned. mcpLog writes JSON to console.error, so each test captures
+ * console.error payloads into a fresh local array (setup.ts installs its own
+ * non-restored console.error spy, so reading spy.mock.calls would leak calls
+ * across tests).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { WorkspaceResolver } from '../src/utils/workspaceResolver';
+
+function makeService(workspaces: Array<{ id: string; name: string }>) {
+  return {
+    getWorkspaces: vi.fn(async () => workspaces)
+  } as any;
+}
+
+/** Capture mcpLog's JSON lines into a local array for the duration of one test. */
+function captureLogs() {
+  const raw: string[] = [];
+  vi.spyOn(console, 'error').mockImplementation((arg?: unknown) => {
+    raw.push(String(arg));
+  });
+  return () =>
+    raw
+      .map(line => {
+        try {
+          return JSON.parse(line) as Record<string, any>;
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is Record<string, any> => entry !== null);
+}
+
+describe('WorkspaceResolver ambiguous case-insensitive match', () => {
+  it('returns the first match and logs an ambiguity warning', async () => {
+    const readLogs = captureLogs();
+    const workspaces = [
+      { id: 'ws-first', name: 'Marketing' },
+      { id: 'ws-second', name: 'marketing' }
+    ];
+    const resolver = new WorkspaceResolver(makeService(workspaces));
+
+    // 'MARKETING' has no exact match, so resolution falls to the
+    // case-insensitive branch where both workspaces qualify.
+    const resolved = await resolver.resolveWorkspace({ workspaceName: 'MARKETING' });
+
+    expect(resolved.id).toBe('ws-first');
+
+    const warnings = readLogs().filter(
+      entry => entry.level === 'warn' && entry.msg === 'Ambiguous case-insensitive workspace match'
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].candidates).toEqual([
+      { id: 'ws-first', name: 'Marketing' },
+      { id: 'ws-second', name: 'marketing' }
+    ]);
+  });
+
+  it('does not warn when an exact match exists even if a case variant is present', async () => {
+    const readLogs = captureLogs();
+    const workspaces = [
+      { id: 'ws-exact', name: 'Marketing' },
+      { id: 'ws-variant', name: 'marketing' }
+    ];
+    const resolver = new WorkspaceResolver(makeService(workspaces));
+
+    const resolved = await resolver.resolveWorkspace({ workspaceName: 'Marketing' });
+
+    expect(resolved.id).toBe('ws-exact');
+    const warnings = readLogs().filter(
+      entry => entry.msg === 'Ambiguous case-insensitive workspace match'
+    );
+    expect(warnings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Adds automated coverage for four already-implemented, previously untested code paths flagged in the #132 review. Tests only; no source changes. All run under the existing plain-Node Vitest project.

## Suites added
- `tests/jsonSchemaToZodObject.spec.ts` — the converted Worker schema enforces `minLength` on task assignee fields, `minimum: 0` on recurring-task duration, and `minItems: 1` on custom-field options. Complements the existing worker spec (which covers `additionalProperties`/`required`/`enum`).
- `tests/paginationTruncation.spec.ts` — `fetchAllPages`: an oversized page stops pagination instead of advancing the cursor and reports the actual returned count; `max_items` takes precedence over `page_size_limit` in the same iteration; the `max_pages` ceiling; the cursor-not-advancing guard.
- `tests/workspaceResolver.ambiguous.spec.ts` — an ambiguous case-insensitive workspace match returns the first match and logs the warning; no warning when an exact match exists.
- `tests/dateFormat.dst.spec.ts` — `endOfDayInZone` across DST boundaries in both directions for a west zone (America/New_York) and an east zone (Australia/Sydney), plus a fixed-offset control (America/Phoenix).

## Verification
- `npx vitest run` — 36 files, 638 tests, all pass
- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p tsconfig.worker.json` — clean

Closes #136

https://claude.ai/code/session_01DWEXxzwrqhGBrKLq68mDHd