### PR TITLE
fix(tasks): dueDate filter drops same-day tasks in zones west of UTC

### DIFF
--- a/src/handlers/TaskHandler.ts
+++ b/src/handlers/TaskHandler.ts
@@ -307,10 +307,13 @@ export class TaskHandler extends BaseHandler {
       ));
     }
 
+    // Resolve the account zone once; reused for filtering by dueDate and for display.
+    const timeZone = await this.resolveTimeZone();
+
     // Validate and parse due date if provided
     let validatedDueDate: string | undefined;
     if (params.dueDate) {
-      const parsedDate = parseFilterDate(params.dueDate, await this.resolveTimeZone());
+      const parsedDate = parseFilterDate(params.dueDate, timeZone);
       if (!parsedDate) {
         return this.handleError(new Error(
           `Invalid date format "${params.dueDate}". Use YYYY-MM-DD format or relative dates like 'today', 'tomorrow'`
@@ -337,7 +340,8 @@ export class TaskHandler extends BaseHandler {
       priority: params.priority as ValidPriority | undefined,
       dueDate: validatedDueDate,
       labels: params.labels,
-      limit: params.limit
+      limit: params.limit,
+      timeZone
     });
 
     const statusDisplay = params.includeAllStatuses
@@ -357,7 +361,7 @@ export class TaskHandler extends BaseHandler {
       dueDate: params.dueDate,
       limit: params.limit,
       truncation,
-      timeZone: await this.resolveTimeZone()
+      timeZone
     });
   }
 

--- a/src/services/api/tasks.ts
+++ b/src/services/api/tasks.ts
@@ -14,6 +14,7 @@ import { TruncationInfo, ListResult } from '../../types/mcp';
 import { ResourceContext } from './types';
 import { getErrorMessage } from './ApiClient';
 import { getWorkspaces } from './workspaces';
+import { calendarDateInZone } from '../../utils/dateFormat';
 
 export interface GetTasksOptions {
   workspaceId?: string;
@@ -27,6 +28,8 @@ export interface GetTasksOptions {
   labels?: string[];
   limit?: number;
   maxPages?: number;
+  /** Account zone for reducing task dueDate instants to a local calendar date when filtering by dueDate. */
+  timeZone?: string;
 }
 
 export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): Promise<ListResult<MotionTask>> {
@@ -41,7 +44,8 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
     dueDate,
     labels,
     limit,
-    maxPages = LIMITS.MAX_PAGES
+    maxPages = LIMITS.MAX_PAGES,
+    timeZone
   } = options;
 
   // Validate limit parameter if provided
@@ -77,10 +81,13 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
         filtered = filtered.filter(t => t.priority === priority);
       }
       if (dueDate) {
-        // Compare date portion only (YYYY-MM-DD)
+        // Compare calendar dates (YYYY-MM-DD). The task's dueDate is a UTC instant,
+        // so reduce it in the account zone before comparing against the filter value
+        // (itself a local calendar date); a raw UTC substring drops same-day tasks
+        // whose UTC date has rolled past midnight in a zone west of UTC.
         filtered = filtered.filter(t => {
           if (!t.dueDate) return false;
-          const taskDate = t.dueDate.substring(0, 10);
+          const taskDate = calendarDateInZone(t.dueDate, timeZone);
           // Upper-bound filter: returns tasks due ON OR BEFORE the given date (inclusive)
           return taskDate <= dueDate;
         });

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -71,11 +71,11 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       workspaceId: {
         type: "string",
-        description: "Filter by workspace (for list)"
+        description: "Filter by workspace (for list). Ignored by list_all_uncompleted, which always spans every workspace."
       },
       workspaceName: {
         type: "string",
-        description: "Filter by workspace name (for list)"
+        description: "Filter by workspace name (for list). Ignored by list_all_uncompleted, which always spans every workspace."
       },
       projectId: {
         type: "string",
@@ -113,7 +113,7 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       dueDate: {
         type: "string",
-        description: "Due date (for create/update) or filter (for list, filtered client-side — returns tasks due on or before this date). Format: YYYY-MM-DD, a full ISO 8601 timestamp with offset, or relative like 'today', 'tomorrow'. A date-only value is stored as end of day (23:59:59) in the account's schedule timezone when all schedules agree on one, so it renders back as the same calendar day; it falls back to end-of-day UTC when no single zone is resolvable. Pass an explicit ISO timestamp with an offset to control the exact instant. Relative keywords resolve against the same account timezone, falling back to UTC otherwise."
+        description: "Due date (for create/update) or filter (for list). Format: YYYY-MM-DD, a full ISO 8601 timestamp with offset, or relative like 'today', 'tomorrow'. FILTER (list): an inclusive upper bound at day granularity in the account timezone — returns every task due ON OR BEFORE that day, which INCLUDES overdue tasks. So dueDate:'today' answers \"what's due today?\" (including anything overdue) in a single list call. There is no exact-date or date-range filter; to show only tasks due exactly on a day, filter the returned results by their Due Date yourself. CREATE/UPDATE: a date-only value is stored as end of day (23:59:59) in the account's schedule timezone when all schedules agree on one, so it renders back as the same calendar day; it falls back to end-of-day UTC when no single zone is resolvable. Pass an explicit ISO timestamp with an offset to control the exact instant. Relative keywords resolve against the same account timezone, falling back to UTC otherwise."
       },
       labels: {
         type: "array",

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -88,6 +88,38 @@ function renderInZone(date: Date, timeZone: string, withTime: boolean): string |
 }
 
 /**
+ * Reduce an instant to its calendar date (YYYY-MM-DD) in a given zone.
+ *
+ * Motion returns dueDate as a UTC instant, so the raw ISO date portion is the
+ * UTC calendar day, which for a zone west of UTC is a day ahead of the local
+ * date near end-of-day. Callers comparing against a local calendar date (e.g.
+ * "today") must reduce the instant in the same zone first, or same-day tasks
+ * whose UTC date has rolled over are silently misclassified.
+ *
+ * Falls back to the UTC date portion when no zone is given or the runtime
+ * cannot honour it; returns the input's leading 10 chars for unparseable input.
+ */
+export function calendarDateInZone(value: string, timeZone?: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+
+  if (timeZone) {
+    try {
+      // en-CA formats as YYYY-MM-DD.
+      return new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }).format(date);
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+/**
  * Format a full timestamp. Always emits the unambiguous ISO 8601 instant;
  * appends a zone-labelled local rendering when a zone is supplied.
  *

--- a/tests/unit/tasks-duedate-filter.test.ts
+++ b/tests/unit/tasks-duedate-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getTasks } from '../../src/services/api/tasks';
+import type { ResourceContext } from '../../src/services/api/types';
+
+function makeMockCtx(tasks: Array<{ id: string; name: string; dueDate?: string }>): ResourceContext {
+  const wrappedResponse = {
+    data: {
+      meta: { pageSize: 20 },
+      tasks,
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any,
+  };
+
+  return {
+    api: {
+      client: { get: vi.fn().mockResolvedValue(wrappedResponse) } as any,
+      requestWithRetry: vi.fn().mockImplementation((fn: () => any) => fn()),
+    } as any,
+    cache: {} as any,
+  };
+}
+
+describe('getTasks dueDate filtering', () => {
+  // Motion returns dueDate as a UTC instant. For an account west of UTC, a task
+  // due end-of-day local time carries a UTC calendar date of the NEXT day.
+  // America/Denver on 2026-08-24 is MDT (UTC-6), so 23:59:59 local -> 05:59:59Z
+  // on 2026-08-25.
+  const denverTasks = [
+    { id: 'overdue', name: 'BeauTeas', dueDate: '2026-08-20T16:00:00.000Z' }, // Aug 20 local
+    { id: 'today-late', name: 'chicken and rice', dueDate: '2026-08-25T05:59:59.000Z' }, // Aug 24 23:59 local
+    { id: 'tomorrow-late', name: 'next day', dueDate: '2026-08-26T05:59:59.000Z' }, // Aug 25 23:59 local
+  ];
+
+  it('includes same-day tasks whose UTC date rolls to the next day (negative offset)', async () => {
+    const ctx = makeMockCtx(denverTasks);
+    const result = await getTasks(ctx, { dueDate: '2026-08-24', timeZone: 'America/Denver' });
+
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).toContain('today-late'); // must not be silently dropped
+  });
+
+  it('returns tasks due on or before the filter date, including overdue', async () => {
+    const ctx = makeMockCtx(denverTasks);
+    const result = await getTasks(ctx, { dueDate: '2026-08-24', timeZone: 'America/Denver' });
+
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['overdue', 'today-late']);
+  });
+
+  it('excludes tasks due after the filter date', async () => {
+    const ctx = makeMockCtx(denverTasks);
+    const result = await getTasks(ctx, { dueDate: '2026-08-24', timeZone: 'America/Denver' });
+
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).not.toContain('tomorrow-late');
+  });
+
+  it('falls back to the UTC date portion when no timeZone is supplied', async () => {
+    const ctx = makeMockCtx(denverTasks);
+    const result = await getTasks(ctx, { dueDate: '2026-08-24' });
+
+    // Without a zone, comparison is on the raw UTC date: only the Aug 20 task qualifies.
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).toEqual(['overdue']);
+  });
+
+  it('skips tasks with no dueDate', async () => {
+    const ctx = makeMockCtx([
+      { id: 'no-due', name: 'someday' },
+      ...denverTasks,
+    ]);
+    const result = await getTasks(ctx, { dueDate: '2026-08-24', timeZone: 'America/Denver' });
+
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).not.toContain('no-due');
+  });
+});


### PR DESCRIPTION
## What

The `motion_tasks` `list` filter by `dueDate` silently dropped tasks due later on the filter day for any account west of UTC, so "what's due today?" returned an incomplete list.

## Root cause

The client-side filter compared the task's **raw UTC** date portion (`t.dueDate.substring(0,10)`) against a **local** calendar filter value (`parseFilterDate` → `currentDateInZone`). Motion stores dueDate as a UTC instant, so a task due end-of-day local time (e.g. `23:59:59-06:00`) is stored as the **next** UTC calendar day (`...T05:59:59Z`). Its UTC date sorted after "today" and was excluded, even though the display path (`formatDateOnly`, which renders in the account zone) showed the correct day. Filter and display disagreed.

This is the real mechanism behind a report that a `dueDate: today` query dropped a task due today at 23:59 while keeping an earlier-dated one.

## Fix

- Add `calendarDateInZone()` in `utils/dateFormat.ts` to reduce an instant to its `YYYY-MM-DD` in a given zone (falls back to the UTC date portion when no zone is resolvable — prior behavior).
- Thread the account zone (already resolved for display) from `TaskHandler` into `getTasks`, and use it in the dueDate comparison.

## Doc improvements (same PR)

- `dueDate`: make the filter semantics explicit — an inclusive on-or-before-day bound that **includes overdue**, so `dueDate:'today'` answers "what's due today?" in one call. Note there is no exact-date/range filter.
- `workspaceId`/`workspaceName`: note `list_all_uncompleted` ignores them and always spans every workspace (documenting existing, intended behavior).

## Semantics confirmed with the maintainer

"What's due today?" should include overdue. The existing on-or-before-day filter already does that; this fix just stops it from dropping same-day tasks. No range filter needed for the common ask.

## Tests

New `tests/unit/tasks-duedate-filter.test.ts` reproduces the negative-offset same-day drop (America/Denver) and asserts the on-or-before (incl. overdue) semantics, exclusion of later days, the no-zone UTC fallback, and skipping tasks with no dueDate. Full suite (675) passes; both type-checks clean.

https://claude.ai/code/session_01HbZLaLAKnrR3ZoZkZUk1Dn