### PR TITLE
feat(tasks): make common Motion asks resolve in one clean call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ Handlers access `this.motionService` (API client) and `this.workspaceResolver` (
 
 Configured via `MOTION_MCP_TOOLS` env var:
 - `minimal` (3): motion_tasks, motion_projects, motion_workspaces
-- `essential` (7): + motion_users, motion_search, motion_comments, motion_schedules
-- `complete` (10, default): + motion_custom_fields, motion_recurring_tasks, motion_statuses
+- `essential` (8): + motion_users, motion_search, motion_comments, motion_schedules, motion_statuses
+- `complete` (10, default): + motion_custom_fields, motion_recurring_tasks
 - `custom:tool1,tool2`: Exact tool selection
 
 ### Core Service (`src/services/motionApi.ts`)

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ All 10 tools are enabled by default. If you run multiple MCP servers and want to
 | Level | Tools | Description |
 |---|---|---|
 | **minimal** | 3 | Tasks, projects, workspaces only |
-| **essential** | 7 | Adds users, search, comments, schedules |
-| **complete** (default) | 10 | Full API access including custom fields, recurring tasks, statuses |
+| **essential** | 8 | Adds users, search, comments, schedules, statuses |
+| **complete** (default) | 10 | Full API access including custom fields and recurring tasks |
 | **custom** | varies | Pick exactly the tools you need |
 
 Custom example:

--- a/src/handlers/TaskHandler.ts
+++ b/src/handlers/TaskHandler.ts
@@ -47,6 +47,8 @@ interface ListTaskParams {
   assignee?: string;
   priority?: string;
   dueDate?: string;
+  completedAfter?: string;
+  completedBefore?: string;
   labels?: string[];
   limit?: number;
 }
@@ -94,6 +96,8 @@ interface UnassignTaskParams {
 interface ListAllUncompletedParams {
   assigneeId?: string;
   assignee?: string;
+  priority?: string;
+  dueDate?: string;
   limit?: number;
 }
 
@@ -322,6 +326,28 @@ export class TaskHandler extends BaseHandler {
       validatedDueDate = parsedDate;
     }
 
+    // Validate and parse completion-date bounds if provided
+    let validatedCompletedAfter: string | undefined;
+    if (params.completedAfter) {
+      const parsed = parseFilterDate(params.completedAfter, timeZone);
+      if (!parsed) {
+        return this.handleError(new Error(
+          `Invalid date format "${params.completedAfter}". Use YYYY-MM-DD format or relative dates like 'today', 'yesterday'`
+        ));
+      }
+      validatedCompletedAfter = parsed;
+    }
+    let validatedCompletedBefore: string | undefined;
+    if (params.completedBefore) {
+      const parsed = parseFilterDate(params.completedBefore, timeZone);
+      if (!parsed) {
+        return this.handleError(new Error(
+          `Invalid date format "${params.completedBefore}". Use YYYY-MM-DD format or relative dates like 'today', 'yesterday'`
+        ));
+      }
+      validatedCompletedBefore = parsed;
+    }
+
     // Validate labels if provided
     if (params.labels && (!Array.isArray(params.labels) || params.labels.some(label => !label || typeof label !== 'string'))) {
       return this.handleError(new Error('Labels must be an array of non-empty strings'));
@@ -339,6 +365,8 @@ export class TaskHandler extends BaseHandler {
       assigneeId: resolvedAssigneeId,
       priority: params.priority as ValidPriority | undefined,
       dueDate: validatedDueDate,
+      completedAfter: validatedCompletedAfter,
+      completedBefore: validatedCompletedBefore,
       labels: params.labels,
       limit: params.limit,
       timeZone
@@ -546,18 +574,45 @@ export class TaskHandler extends BaseHandler {
    * @returns Formatted list of uncompleted tasks from all workspaces
    */
   private async handleListAllUncompleted(params: ListAllUncompletedParams): Promise<McpToolResponse> {
+    if (params.priority && !isValidPriority(params.priority)) {
+      return this.handleError(new Error(
+        `Invalid priority "${params.priority}". Valid values are: ASAP, HIGH, MEDIUM, LOW`
+      ));
+    }
+
+    const timeZone = await this.resolveTimeZone();
+
+    let validatedDueDate: string | undefined;
+    if (params.dueDate) {
+      const parsedDate = parseFilterDate(params.dueDate, timeZone);
+      if (!parsedDate) {
+        return this.handleError(new Error(
+          `Invalid date format "${params.dueDate}". Use YYYY-MM-DD format or relative dates like 'today', 'tomorrow'`
+        ));
+      }
+      validatedDueDate = parsedDate;
+    }
+
     const { resolvedId, display } =
       await this.resolveAssignee(params.assigneeId, params.assignee);
 
-    const { items: tasks, truncation } = await this.motionService.getAllUncompletedTasks(params.limit, resolvedId);
+    const { items: tasks, truncation } = await this.motionService.getAllUncompletedTasks({
+      limit: params.limit,
+      assigneeId: resolvedId,
+      dueDate: validatedDueDate,
+      priority: params.priority as ValidPriority | undefined,
+      timeZone
+    });
 
     return formatTaskList(tasks, {
       status: 'uncompleted',
       assigneeName: display || resolvedId,
+      priority: params.priority,
+      dueDate: params.dueDate,
       limit: params.limit,
       allWorkspaces: true,
       truncation,
-      timeZone: await this.resolveTimeZone()
+      timeZone
     });
   }
 

--- a/src/services/api/tasks.ts
+++ b/src/services/api/tasks.ts
@@ -25,10 +25,14 @@ export interface GetTasksOptions {
   assigneeId?: string;
   priority?: ValidPriority;
   dueDate?: string;
+  /** Keep only tasks completed on or after this local calendar date (YYYY-MM-DD). Implies includeAllStatuses. */
+  completedAfter?: string;
+  /** Keep only tasks completed on or before this local calendar date (YYYY-MM-DD). Implies includeAllStatuses. */
+  completedBefore?: string;
   labels?: string[];
   limit?: number;
   maxPages?: number;
-  /** Account zone for reducing task dueDate instants to a local calendar date when filtering by dueDate. */
+  /** Account zone for reducing task dueDate/completedTime instants to a local calendar date when filtering. */
   timeZone?: string;
 }
 
@@ -42,11 +46,18 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
     assigneeId,
     priority,
     dueDate,
+    completedAfter,
+    completedBefore,
     labels,
     limit,
     maxPages = LIMITS.MAX_PAGES,
     timeZone
   } = options;
+
+  // A completion-date filter needs completed/resolved tasks in the fetch, which the
+  // API omits by default. Imply includeAllStatuses so those tasks are present to filter.
+  const wantsCompleted = Boolean(completedAfter || completedBefore);
+  const effectiveIncludeAllStatuses = includeAllStatuses || wantsCompleted;
 
   // Validate limit parameter if provided
   if (limit !== undefined && (limit < 0 || !Number.isInteger(limit))) {
@@ -92,6 +103,17 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
           return taskDate <= dueDate;
         });
       }
+      if (completedAfter || completedBefore) {
+        // Compare completion date at day granularity in the account zone (completedTime
+        // is a UTC instant, the bounds are local calendar dates). Both ends inclusive.
+        filtered = filtered.filter(t => {
+          if (!t.completedTime) return false;
+          const done = calendarDateInZone(t.completedTime, timeZone);
+          if (completedAfter && done < completedAfter) return false;
+          if (completedBefore && done > completedBefore) return false;
+          return true;
+        });
+      }
       return filtered;
     };
 
@@ -118,7 +140,7 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
           params.append('status', status);
         }
       }
-      if (includeAllStatuses) {
+      if (effectiveIncludeAllStatuses) {
         params.append('includeAllStatuses', 'true');
       }
       if (assigneeId) {
@@ -147,7 +169,7 @@ export async function getTasks(ctx: ResourceContext, options: GetTasksOptions): 
       // When client-side filters are active, don't cap pagination with maxItems
       // because valid matches may exist beyond the first batch. Fetch all pages
       // and apply the limit after filtering instead.
-      const hasClientFilters = Boolean(name || priority || dueDate);
+      const hasClientFilters = Boolean(name || priority || dueDate || completedAfter || completedBefore);
       const paginatedResult = await fetchAllPagesNew<MotionTask>(fetchPage, 'tasks', {
         maxPages,
         logProgress: false,  // Less verbose for tasks
@@ -450,12 +472,25 @@ export async function unassignTask(ctx: ResourceContext, taskId: string): Promis
  * Get all uncompleted tasks across all workspaces and projects
  * Filters tasks where status.isResolvedStatus is false or undefined
  */
-export async function getAllUncompletedTasks(ctx: ResourceContext, limit?: number, assigneeId?: string): Promise<ListResult<MotionTask>> {
+export interface GetAllUncompletedOptions {
+  limit?: number;
+  assigneeId?: string;
+  /** Keep only tasks due ON OR BEFORE this local calendar date (YYYY-MM-DD or a validated date). */
+  dueDate?: string;
+  priority?: ValidPriority;
+  /** Account zone for reducing task dueDate instants to a local calendar date when filtering by dueDate. */
+  timeZone?: string;
+}
+
+export async function getAllUncompletedTasks(ctx: ResourceContext, options: GetAllUncompletedOptions = {}): Promise<ListResult<MotionTask>> {
+  const { limit, assigneeId, dueDate, priority, timeZone } = options;
   try {
     mcpLog(LOG_LEVELS.DEBUG, 'Fetching all uncompleted tasks across workspaces', {
       method: 'getAllUncompletedTasks',
       limit,
-      assigneeId
+      assigneeId,
+      dueDate,
+      priority
     });
 
     // Apply limit to prevent resource exhaustion
@@ -487,6 +522,9 @@ export async function getAllUncompletedTasks(ctx: ResourceContext, limit?: numbe
           const { items: workspaceTasks, truncation: wsTruncation } = await getTasks(ctx, {
             workspaceId: workspace.id,
             assigneeId,
+            dueDate,
+            priority,
+            timeZone,
             limit: fetchLimit,
             maxPages: LIMITS.MAX_PAGES
           });

--- a/src/services/motionApi.ts
+++ b/src/services/motionApi.ts
@@ -32,7 +32,7 @@ import type { IApiClient, ResourceContext } from './api/types';
 // Resource module imports
 import { getWorkspaces as _getWorkspaces } from './api/workspaces';
 import { getUsers as _getUsers, getCurrentUser as _getCurrentUser } from './api/users';
-import { getTasks as _getTasks, getTask as _getTask, createTask as _createTask, updateTask as _updateTask, deleteTask as _deleteTask, moveTask as _moveTask, unassignTask as _unassignTask, getAllUncompletedTasks as _getAllUncompletedTasks } from './api/tasks';
+import { getTasks as _getTasks, getTask as _getTask, createTask as _createTask, updateTask as _updateTask, deleteTask as _deleteTask, moveTask as _moveTask, unassignTask as _unassignTask, getAllUncompletedTasks as _getAllUncompletedTasks, GetAllUncompletedOptions } from './api/tasks';
 import type { GetTasksOptions } from './api/tasks';
 import { getProjects as _getProjects, getAllProjects as _getAllProjects, getProject as _getProject, createProject as _createProject, updateProject as _updateProject, deleteProject as _deleteProject, getProjectByName as _getProjectByName } from './api/projects';
 import { getComments as _getComments, createComment as _createComment } from './api/comments';
@@ -109,8 +109,8 @@ export class MotionApiService {
     return _unassignTask(this._ctx, taskId);
   }
 
-  async getAllUncompletedTasks(limit?: number, assigneeId?: string): Promise<ListResult<MotionTask>> {
-    return _getAllUncompletedTasks(this._ctx, limit, assigneeId);
+  async getAllUncompletedTasks(options: GetAllUncompletedOptions = {}): Promise<ListResult<MotionTask>> {
+    return _getAllUncompletedTasks(this._ctx, options);
   }
 
   // ========================================

--- a/src/tools/ToolDefinitions.ts
+++ b/src/tools/ToolDefinitions.ts
@@ -108,12 +108,20 @@ export const tasksToolDefinition: McpToolDefinition = {
       },
       priority: {
         type: "string",
-        description: "Task priority: ASAP, HIGH, MEDIUM, LOW. Set on create/update; filters results on list (filtered client-side)",
+        description: "Task priority: ASAP, HIGH, MEDIUM, LOW. Set on create/update; filters results on list and list_all_uncompleted (filtered client-side)",
         enum: ["ASAP", "HIGH", "MEDIUM", "LOW"]
       },
       dueDate: {
         type: "string",
-        description: "Due date (for create/update) or filter (for list). Format: YYYY-MM-DD, a full ISO 8601 timestamp with offset, or relative like 'today', 'tomorrow'. FILTER (list): an inclusive upper bound at day granularity in the account timezone — returns every task due ON OR BEFORE that day, which INCLUDES overdue tasks. So dueDate:'today' answers \"what's due today?\" (including anything overdue) in a single list call. There is no exact-date or date-range filter; to show only tasks due exactly on a day, filter the returned results by their Due Date yourself. CREATE/UPDATE: a date-only value is stored as end of day (23:59:59) in the account's schedule timezone when all schedules agree on one, so it renders back as the same calendar day; it falls back to end-of-day UTC when no single zone is resolvable. Pass an explicit ISO timestamp with an offset to control the exact instant. Relative keywords resolve against the same account timezone, falling back to UTC otherwise."
+        description: "Due date (for create/update) or filter (for list and list_all_uncompleted). Format: YYYY-MM-DD, a full ISO 8601 timestamp with offset, or relative like 'today', 'tomorrow'. FILTER (list, list_all_uncompleted): an inclusive upper bound at day granularity in the account timezone — returns every task due ON OR BEFORE that day, which INCLUDES overdue tasks. So dueDate:'today' answers \"what's due today?\" (including anything overdue) in a single call. There is no exact-date or date-range filter; to show only tasks due exactly on a day, filter the returned results by their Due Date yourself. CREATE/UPDATE: a date-only value is stored as end of day (23:59:59) in the account's schedule timezone when all schedules agree on one, so it renders back as the same calendar day; it falls back to end-of-day UTC when no single zone is resolvable. Pass an explicit ISO timestamp with an offset to control the exact instant. Relative keywords resolve against the same account timezone, falling back to UTC otherwise."
+      },
+      completedAfter: {
+        type: "string",
+        description: "Filter (for list): keep only tasks COMPLETED on or after this local calendar date. Format: YYYY-MM-DD or relative like 'today', 'yesterday'. Filtered client-side and auto-includes completed/resolved tasks, so 'what did I get done this week?' is completedAfter set to the week's start date. Combine with completedBefore for a window. Note: this filters on completion date, not due date; a very high-volume window can be capped by pagination (reported in the response), not silently."
+      },
+      completedBefore: {
+        type: "string",
+        description: "Filter (for list): keep only tasks COMPLETED on or before this local calendar date. Format: YYYY-MM-DD or relative like 'today'. Filtered client-side; pair with completedAfter to bound a completion window."
       },
       labels: {
         type: "array",
@@ -484,7 +492,7 @@ export const recurringTasksToolDefinition: McpToolDefinition = {
 
 export const schedulesToolDefinition: McpToolDefinition = {
   name: TOOL_NAMES.SCHEDULES,
-  description: "Get all schedules showing weekly working hours and time zones. The Motion API returns all schedules with no filtering options.",
+  description: "Get all schedules showing each day's working hours (start-end per day) and time zones. The Motion API returns all schedules with no filtering options. These are recurring working-hour templates only — they do NOT expose actual calendar events or meetings, so they cannot by themselves show a true free/busy picture; combine with tasks' scheduledStart/scheduledEnd to see what Motion has auto-booked.",
   inputSchema: {
     type: "object",
     properties: {

--- a/src/tools/ToolRegistry.ts
+++ b/src/tools/ToolRegistry.ts
@@ -53,7 +53,7 @@ export class ToolRegistry {
    *
    * Supported configurations:
    * - 'minimal': Core tools only (tasks, projects, workspaces) - 3 tools
-   * - 'essential': Core plus common features (users, search, comments, schedules) - 7 tools
+   * - 'essential': Core plus common features (users, search, comments, schedules, statuses) - 8 tools
    * - 'complete': All available tools - 10 tools
    * - 'custom:tool1,tool2,...': Specific tools by name
    *
@@ -80,7 +80,10 @@ export class ToolRegistry {
           toolsMap.get(TOOL_NAMES.USERS),
           toolsMap.get(TOOL_NAMES.SEARCH),
           toolsMap.get(TOOL_NAMES.COMMENTS),
-          toolsMap.get(TOOL_NAMES.SCHEDULES)
+          toolsMap.get(TOOL_NAMES.SCHEDULES),
+          // Statuses lets the model resolve a workspace's done/resolved status name
+          // instead of guessing it when marking tasks complete.
+          toolsMap.get(TOOL_NAMES.STATUSES)
         ].filter((tool): tool is McpToolDefinition => tool !== undefined);
 
       case 'complete':

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -512,22 +512,33 @@ export function formatScheduleList(schedules: MotionSchedule[]): CallToolResult 
     const name = schedule.name || 'Unnamed';
     const timezone = schedule.timezone || 'Unknown timezone';
     
-    // Count working days if schedule details are available
-    let workingDays = '';
+    // Surface each working day's hours (start-end per slot) so callers can reason
+    // about actual availability, not just how many days are worked.
+    let workingHours = '';
     if (schedule.schedule && typeof schedule.schedule === 'object') {
-      const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
-      const activeDays = days.filter(day => 
-        Array.isArray(schedule.schedule[day as keyof MotionScheduleDetails]) && 
-        schedule.schedule[day as keyof MotionScheduleDetails]!.length > 0
-      );
-      workingDays = activeDays.length > 0 
-        ? ` | Working days: ${activeDays.length}/7` 
+      const dayDefs: Array<[keyof MotionScheduleDetails, string]> = [
+        ['monday', 'Mon'], ['tuesday', 'Tue'], ['wednesday', 'Wed'], ['thursday', 'Thu'],
+        ['friday', 'Fri'], ['saturday', 'Sat'], ['sunday', 'Sun']
+      ];
+      const dayParts: string[] = [];
+      for (const [key, label] of dayDefs) {
+        const slots = schedule.schedule[key];
+        if (Array.isArray(slots) && slots.length > 0) {
+          const hours = slots
+            .filter(slot => slot && slot.start && slot.end)
+            .map(slot => `${slot.start}-${slot.end}`)
+            .join('/');
+          if (hours) dayParts.push(`${label} ${hours}`);
+        }
+      }
+      workingHours = dayParts.length > 0
+        ? ` | ${dayParts.join(', ')}`
         : ' | No working hours defined';
     } else {
-      workingDays = ' | Schedule details unavailable';
+      workingHours = ' | Schedule details unavailable';
     }
-    
-    return `- ${name} (${timezone})${workingDays}`;
+
+    return `- ${name} (${timezone})${workingHours}`;
   };
   
   return formatListResponse(schedules, `Found ${schedules.length} schedule${schedules.length === 1 ? '' : 's'}`, scheduleFormatter);

--- a/tests/schedule-hours-formatter.spec.ts
+++ b/tests/schedule-hours-formatter.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { formatScheduleList } from '../src/utils/responseFormatters';
+import type { MotionSchedule } from '../src/types/motion';
+
+function text(res: any): string {
+  return (res.content?.[0] as any)?.text || '';
+}
+
+describe('formatScheduleList working hours', () => {
+  it('renders each working day start-end from the nested schedule details', () => {
+    const schedules = [
+      {
+        name: 'Work hours',
+        isDefaultTimezone: true,
+        timezone: 'America/Denver',
+        schedule: {
+          monday: [{ start: '09:00', end: '17:00' }],
+          tuesday: [{ start: '09:00', end: '17:00' }],
+          friday: [{ start: '09:00', end: '12:00' }],
+        },
+      },
+    ] as MotionSchedule[];
+
+    const out = text(formatScheduleList(schedules));
+    expect(out).toContain('Work hours (America/Denver)');
+    expect(out).toContain('Mon 09:00-17:00');
+    expect(out).toContain('Fri 09:00-12:00');
+    expect(out).not.toContain('Wed'); // no wednesday slot
+  });
+
+  it('joins multiple slots in a day with a slash', () => {
+    const schedules = [
+      {
+        name: 'Split',
+        isDefaultTimezone: true,
+        timezone: 'America/Denver',
+        schedule: { monday: [{ start: '09:00', end: '12:00' }, { start: '13:00', end: '17:00' }] },
+      },
+    ] as MotionSchedule[];
+    expect(text(formatScheduleList(schedules))).toContain('Mon 09:00-12:00/13:00-17:00');
+  });
+
+  it('reports when a schedule has no working hours', () => {
+    const schedules = [
+      { name: 'Empty', isDefaultTimezone: true, timezone: 'UTC', schedule: {} },
+    ] as MotionSchedule[];
+    expect(text(formatScheduleList(schedules))).toContain('No working hours defined');
+  });
+});

--- a/tests/services/facade-contract.spec.ts
+++ b/tests/services/facade-contract.spec.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import type { MotionApiService } from '../../src/services/motionApi';
+import type { GetAllUncompletedOptions } from '../../src/services/api/tasks';
 import type {
   MotionWorkspace,
   MotionProject,
@@ -102,7 +103,7 @@ type _unassignTask = AssertMethod<
 const _tt7: _unassignTask = null! as MotionApiService['unassignTask'];
 
 type _getAllUncompletedTasks = AssertMethod<
-  (this: MotionApiService, limit?: number, assigneeId?: string) => Promise<ListResult<MotionTask>>
+  (this: MotionApiService, options?: GetAllUncompletedOptions) => Promise<ListResult<MotionTask>>
 >;
 const _tt8: _getAllUncompletedTasks = null! as MotionApiService['getAllUncompletedTasks'];
 

--- a/tests/toolConfigurator.spec.ts
+++ b/tests/toolConfigurator.spec.ts
@@ -26,7 +26,7 @@ describe('ToolConfigurator', () => {
     expect(names.length).toBe(3);
   });
 
-  it('essential preset exposes expected 7 tools', () => {
+  it('essential preset exposes expected 8 tools', () => {
     const cfg = new ToolConfigurator('essential', registry);
     const tools = cfg.getEnabledTools();
     const names = tools.map(t => t.name);
@@ -38,8 +38,9 @@ describe('ToolConfigurator', () => {
       TOOL_NAMES.SEARCH,
       TOOL_NAMES.COMMENTS,
       TOOL_NAMES.SCHEDULES,
+      TOOL_NAMES.STATUSES,
     ]));
-    expect(names.length).toBe(7);
+    expect(names.length).toBe(8);
   });
 
   it('complete preset exposes expected 10 tools', () => {

--- a/tests/unit/tasks-all-uncompleted-filter.test.ts
+++ b/tests/unit/tasks-all-uncompleted-filter.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getAllUncompletedTasks } from '../../src/services/api/tasks';
+import type { ResourceContext } from '../../src/services/api/types';
+
+// Two workspaces, each with its own task set. getAllUncompletedTasks fetches /workspaces
+// then /tasks?workspaceId=... per workspace and applies dueDate/priority via getTasks.
+function makeMockCtx(workspaces: Array<{ id: string; name: string }>, tasksByWs: Record<string, any[]>) {
+  const get = vi.fn().mockImplementation((url: string) => {
+    if (url.startsWith('/workspaces')) {
+      return Promise.resolve({ data: { workspaces }, status: 200, statusText: 'OK', headers: {}, config: {} });
+    }
+    const params = new URLSearchParams(url.split('?')[1] || '');
+    const wsId = params.get('workspaceId') || '';
+    return Promise.resolve({
+      data: { meta: { pageSize: 20 }, tasks: tasksByWs[wsId] || [] },
+      status: 200, statusText: 'OK', headers: {}, config: {},
+    });
+  });
+
+  const ctx = {
+    api: {
+      client: { get } as any,
+      requestWithRetry: vi.fn().mockImplementation((fn: () => any) => fn()),
+      validateResponse: (data: unknown) => data,
+      mergeTruncationMetadata: (a: unknown, b: unknown) => b || a,
+      formatApiError: (e: unknown) => e,
+    } as any,
+    cache: { workspace: { withCache: (_k: string, fn: () => any) => fn() } } as any,
+  } as ResourceContext;
+
+  return { ctx, get };
+}
+
+const workspaces = [{ id: 'ws1', name: 'One' }, { id: 'ws2', name: 'Two' }];
+const tasksByWs = {
+  ws1: [
+    { id: 'A', name: 'A', status: 'Todo', priority: 'HIGH', dueDate: '2026-08-25T05:59:59.999Z' }, // Denver 08-24
+    { id: 'B', name: 'B', status: 'Todo', priority: 'MEDIUM', dueDate: '2026-09-10T05:59:59.999Z' }, // future
+  ],
+  ws2: [
+    { id: 'C', name: 'C', status: 'Todo', priority: 'HIGH', dueDate: '2026-08-20T06:00:00.000Z' }, // Denver 08-20
+    { id: 'D', name: 'D', status: 'Todo', priority: 'HIGH', dueDate: null }, // no due date
+  ],
+};
+
+describe('getAllUncompletedTasks cross-workspace filtering', () => {
+  it('honors dueDate across workspaces (on or before, account zone)', async () => {
+    const { ctx } = makeMockCtx(workspaces, tasksByWs);
+    const result = await getAllUncompletedTasks(ctx, { assigneeId: 'me', dueDate: '2026-08-24', timeZone: 'America/Denver' });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['A', 'C']); // B is future, D has no due date
+  });
+
+  it('honors priority across workspaces', async () => {
+    const { ctx } = makeMockCtx(workspaces, tasksByWs);
+    const result = await getAllUncompletedTasks(ctx, { assigneeId: 'me', priority: 'HIGH' });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['A', 'C', 'D']); // all HIGH, no date filter
+  });
+
+  it('combines dueDate and priority', async () => {
+    const { ctx } = makeMockCtx(workspaces, tasksByWs);
+    const result = await getAllUncompletedTasks(ctx, {
+      assigneeId: 'me', priority: 'HIGH', dueDate: '2026-08-24', timeZone: 'America/Denver',
+    });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['A', 'C']);
+  });
+
+  it('returns all uncompleted when no filters given', async () => {
+    const { ctx } = makeMockCtx(workspaces, tasksByWs);
+    const result = await getAllUncompletedTasks(ctx, { assigneeId: 'me' });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['A', 'B', 'C', 'D']);
+  });
+});

--- a/tests/unit/tasks-completed-filter.test.ts
+++ b/tests/unit/tasks-completed-filter.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getTasks } from '../../src/services/api/tasks';
+import type { ResourceContext } from '../../src/services/api/types';
+
+function makeMockCtx(tasks: Array<Record<string, unknown>>) {
+  const get = vi.fn().mockResolvedValue({
+    data: { meta: { pageSize: 20 }, tasks },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as any,
+  });
+  return {
+    ctx: {
+      api: {
+        client: { get } as any,
+        requestWithRetry: vi.fn().mockImplementation((fn: () => any) => fn()),
+      } as any,
+      cache: {} as any,
+    } as ResourceContext,
+    get,
+  };
+}
+
+describe('getTasks completion-date filtering', () => {
+  // completedTime is a UTC instant; the bounds are local calendar dates. Denver = UTC-6 (MDT).
+  const tasks = [
+    { id: 'early', name: 'a', completed: true, completedTime: '2026-08-16T10:00:00.000Z' }, // Denver 08-16
+    { id: 'mid', name: 'b', completed: true, completedTime: '2026-08-20T18:00:00.000Z' }, // Denver 08-20
+    { id: 'late', name: 'c', completed: true, completedTime: '2026-08-25T05:00:00.000Z' }, // Denver 08-24 23:00
+    { id: 'open', name: 'd', completed: false }, // never completed
+  ];
+
+  it('keeps tasks completed on or after completedAfter (account zone)', async () => {
+    const { ctx } = makeMockCtx(tasks);
+    const result = await getTasks(ctx, { completedAfter: '2026-08-18', timeZone: 'America/Denver' });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['late', 'mid']);
+  });
+
+  it('keeps tasks completed on or before completedBefore (account zone)', async () => {
+    const { ctx } = makeMockCtx(tasks);
+    const result = await getTasks(ctx, { completedBefore: '2026-08-20', timeZone: 'America/Denver' });
+    const ids = result.items.map((t: any) => t.id).sort();
+    expect(ids).toEqual(['early', 'mid']);
+  });
+
+  it('bounds a completion window with both ends inclusive', async () => {
+    const { ctx } = makeMockCtx(tasks);
+    const result = await getTasks(ctx, {
+      completedAfter: '2026-08-18',
+      completedBefore: '2026-08-22',
+      timeZone: 'America/Denver',
+    });
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).toEqual(['mid']);
+  });
+
+  it('excludes tasks with no completedTime', async () => {
+    const { ctx } = makeMockCtx(tasks);
+    const result = await getTasks(ctx, { completedAfter: '2000-01-01', timeZone: 'America/Denver' });
+    const ids = result.items.map((t: any) => t.id);
+    expect(ids).not.toContain('open');
+  });
+
+  it('implies includeAllStatuses in the fetch so completed tasks are present', async () => {
+    const { ctx, get } = makeMockCtx(tasks);
+    await getTasks(ctx, { completedAfter: '2026-08-18', timeZone: 'America/Denver' });
+    const url = get.mock.calls[0][0] as string;
+    expect(url).toContain('includeAllStatuses=true');
+  });
+});

--- a/tests/unit/toolConfiguration.test.ts
+++ b/tests/unit/toolConfiguration.test.ts
@@ -57,9 +57,9 @@ describe('ToolRegistry', () => {
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.WORKSPACES);
     });
 
-    it('returns 7 tools for essential config', () => {
+    it('returns 8 tools for essential config', () => {
       const tools = registry.getEnabled('essential');
-      expect(tools.length).toBe(7);
+      expect(tools.length).toBe(8);
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.TASKS);
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.PROJECTS);
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.WORKSPACES);
@@ -67,6 +67,7 @@ describe('ToolRegistry', () => {
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.SEARCH);
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.COMMENTS);
       expect(tools.map(t => t.name)).toContain(TOOL_NAMES.SCHEDULES);
+      expect(tools.map(t => t.name)).toContain(TOOL_NAMES.STATUSES);
     });
 
     it('returns 10 tools for complete config', () => {
@@ -177,7 +178,7 @@ describe('ToolConfigurator', () => {
 
     it('returns correct tool count for essential', () => {
       const configurator = new ToolConfigurator('essential', registry);
-      expect(configurator.getToolCount()).toBe(7);
+      expect(configurator.getToolCount()).toBe(8);
     });
 
     it('returns correct tool count for complete', () => {


### PR DESCRIPTION
## Why

Testing real user prompts against the deployed server surfaced four spots where a common ask either flailed or silently returned the wrong set. Each is fixed so the natural query resolves in one clean call.

## Changes

**1. `list_all_uncompleted` honors `dueDate` and `priority`.** It accepted these params (they live on the shared `motion_tasks` schema) but silently dropped every filter except `assignee`/`limit` — so "what's due this week across all my workspaces" returned everything, and an agent had to filter ~90 tasks client-side. Now `dueDate` (validated, account-zone) and `priority` thread through `getAllUncompletedTasks` into the per-workspace `getTasks` calls that already filter. `getAllUncompletedTasks` now takes an options object.

**2. `list` gains `completedAfter` / `completedBefore`.** Motion has no server-side completion-date filter, so "what did I get done this week?" meant dumping all statuses (500-cap, ~340KB response) and filtering by hand. These client-side bounds (day granularity in the account zone, both ends inclusive) auto-imply `includeAllStatuses`. A very large window is still bounded by `MAX_PAGES` — surfaced in truncation metadata, not silently.

**3. Schedule working hours.** `formatScheduleList` now prints each day's `start-end` (per slot) instead of only a working-days count. The times were already in the payload (`MotionScheduleDetails`), just dropped — so "when am I free today?" can anchor to real hours. The `motion_schedules` description now states these are working-hour templates that do **not** expose calendar events/meetings.

**4. `motion_statuses` added to the `essential` tier.** Marking a task done previously required guessing the workspace's resolved-status string (`motion_statuses` was only in `complete`). It's now in `essential` so the model can look it up. Tier is 8 tools; docs and tier-count tests updated.

## How this was found

Ran 12 representative prompts as isolated fresh agents against the live cloud server (read-only in parallel, mutations against a dedicated test project, cleaned up after). Daily-driver reads already resolved in 1 call; these four were the friction points. The timezone `dueDate` fix from #148 was also validated live end-to-end.

## Tests

New: completion-date filter, cross-workspace `dueDate`/`priority` passthrough, schedule-hours formatter. Updated: tier-count assertions (7 → 8) and tier docs. Full suite (687) green; both type-checks clean.

## Note

The `completedAfter`/`completedBefore` window can still be truncated by the `MAX_PAGES` fetch cap on very high-volume periods; that truncation is reported, not silent. A server-side completion-date filter would remove the cap but Motion's API doesn't offer one.

https://claude.ai/code/session_01HbZLaLAKnrR3ZoZkZUk1Dn