### PR TITLE
feat(formatters): surface account timezone + today's local date on list responses

### DIFF
--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -88,6 +88,45 @@ function renderInZone(date: Date, timeZone: string, withTime: boolean): string |
 }
 
 /**
+ * One-line account date context: the resolved account timezone plus today's
+ * local date and weekday in that zone. Prepended to list responses so the model
+ * reasons about "this week", weekdays, and "now" against the account's actual
+ * zone instead of guessing (the wall-clock date it has from its own context is
+ * in an unknown zone, and nothing else in the payload states the account zone).
+ *
+ * `now` is injectable so callers/tests can pin the clock; production passes the
+ * real time. Falls back to a UTC-labelled reading when no usable zone is given.
+ */
+export function formatAccountDateContext(timeZone?: string, now: Date = new Date()): string {
+  const usableZone = timeZone && isValidTimeZone(timeZone) ? timeZone : undefined;
+  const zone = usableZone ?? 'UTC';
+  try {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: zone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      weekday: 'long'
+    })
+      .formatToParts(now)
+      .reduce<Record<string, string>>((acc, part) => {
+        acc[part.type] = part.value;
+        return acc;
+      }, {});
+
+    if (parts.year && parts.month && parts.day) {
+      const date = `${parts.year}-${parts.month}-${parts.day}`;
+      const weekday = parts.weekday ? ` (${parts.weekday})` : '';
+      const label = usableZone ?? 'unknown (times shown in UTC)';
+      return `Account timezone: ${label} | Today: ${date}${weekday}`;
+    }
+  } catch {
+    // fall through to a minimal UTC reading
+  }
+  return `Account timezone: ${usableZone ?? 'unknown (times shown in UTC)'} | Today: ${now.toISOString().slice(0, 10)}`;
+}
+
+/**
  * Reduce an instant to its calendar date (YYYY-MM-DD) in a given zone.
  *
  * Motion returns dueDate as a UTC instant, so the raw ISO date portion is the

--- a/src/utils/responseFormatters.ts
+++ b/src/utils/responseFormatters.ts
@@ -11,7 +11,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MotionProject, MotionTask, MotionWorkspace, MotionComment, MotionCustomField, MotionCustomFieldValue, MotionRecurringTask, MotionSchedule, MotionScheduleDetails, MotionStatus } from '../types/motion';
 import { TruncationInfo } from '../types/mcp';
 import { LIMITS } from './constants';
-import { formatTimestamp, formatDateOnly } from './dateFormat';
+import { formatTimestamp, formatDateOnly, formatAccountDateContext, resolveDisplayTimeZone } from './dateFormat';
 
 const TRUNCATION_REASON_MESSAGES: Record<string, string> = {
   page_size_limit: 'due to page size limits',
@@ -166,7 +166,7 @@ export function formatTaskList(
   if (limit) title += ` (limit: ${limit})`;
 
   const list = tasks.map(taskFormatter).join('\n');
-  let responseText = `${title}:\n${list}`;
+  let responseText = `${formatAccountDateContext(timeZone)}\n${title}:\n${list}`;
   responseText += formatTruncationNotice(truncation);
 
   const structured: Record<string, unknown> = {
@@ -540,8 +540,11 @@ export function formatScheduleList(schedules: MotionSchedule[]): CallToolResult 
 
     return `- ${name} (${timezone})${workingHours}`;
   };
-  
-  return formatListResponse(schedules, `Found ${schedules.length} schedule${schedules.length === 1 ? '' : 's'}`, scheduleFormatter);
+
+  const contextLine = formatAccountDateContext(resolveDisplayTimeZone(schedules));
+  const list = schedules.map(scheduleFormatter).join('\n');
+  const title = `Found ${schedules.length} schedule${schedules.length === 1 ? '' : 's'}`;
+  return formatMcpSuccess(`${contextLine}\n${title}:\n${list}`);
 }
 
 export function formatStatusList(statuses: MotionStatus[]): CallToolResult {

--- a/tests/date-context-formatter.spec.ts
+++ b/tests/date-context-formatter.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { formatAccountDateContext } from '../src/utils/dateFormat';
+import { formatTaskList, formatScheduleList } from '../src/utils/responseFormatters';
+import type { MotionSchedule, MotionTask } from '../src/types/motion';
+
+function textOf(res: any): string {
+  return (res.content?.[0] as any)?.text || '';
+}
+
+describe('formatAccountDateContext', () => {
+  it('reports the account zone and local date/weekday for a pinned instant', () => {
+    // 2026-08-24T20:00:00Z = 14:00 MDT (UTC-6) on Monday Aug 24 in Denver.
+    const line = formatAccountDateContext('America/Denver', new Date('2026-08-24T20:00:00.000Z'));
+    expect(line).toBe('Account timezone: America/Denver | Today: 2026-08-24 (Monday)');
+  });
+
+  it('resolves the local calendar day, not the UTC day, near midnight', () => {
+    // 04:00Z is still 22:00 the previous day (Sunday Aug 23) in Denver.
+    const line = formatAccountDateContext('America/Denver', new Date('2026-08-24T04:00:00.000Z'));
+    expect(line).toContain('Today: 2026-08-23 (Sunday)');
+  });
+
+  it('falls back to a UTC-labelled reading when no zone is given', () => {
+    const line = formatAccountDateContext(undefined, new Date('2026-08-24T20:00:00.000Z'));
+    expect(line).toContain('unknown (times shown in UTC)');
+    expect(line).toContain('Today: 2026-08-24');
+  });
+
+  it('falls back when the zone is not a valid IANA id', () => {
+    const line = formatAccountDateContext('Not/AZone', new Date('2026-08-24T20:00:00.000Z'));
+    expect(line).toContain('unknown (times shown in UTC)');
+  });
+});
+
+describe('account context in list responses', () => {
+  it('prepends the account context line to task lists', () => {
+    const tasks = [{ id: 't1', name: 'A' }] as MotionTask[];
+    const text = textOf(formatTaskList(tasks, { timeZone: 'America/Denver' }));
+    expect(text).toContain('Account timezone: America/Denver | Today:');
+    expect(text.startsWith('Account timezone:')).toBe(true);
+  });
+
+  it('derives the account context zone from the schedules for schedule lists', () => {
+    const schedules = [
+      { name: 'Work hours', isDefaultTimezone: true, timezone: 'America/Denver', schedule: {} },
+    ] as MotionSchedule[];
+    const text = textOf(formatScheduleList(schedules));
+    expect(text).toContain('Account timezone: America/Denver | Today:');
+    expect(text).toContain('Work hours');
+  });
+});


### PR DESCRIPTION
Closes #150.

## Why

Date-relative reasoning ("what's due this week?", "when am I free today?") had nothing in the payload stating the account's timezone. The model knows the wall-clock date from its own context but not that the account is, say, `America/Denver` — so in live testing fresh agents inferred "now" from the newest task `updatedTime` stamp and sometimes reported the wrong weekday ("Sunday" on a Monday). Relative filters the model delegates to the server (`dueDate:'today'`) already resolve correctly; the gap is the date reasoning the model does itself.

## What

- New `formatAccountDateContext(timeZone, now?)` in `dateFormat.ts` returns one line: `Account timezone: America/Denver | Today: 2026-08-24 (Monday)`. Built from `Intl.formatToParts` (order-independent, workerd-safe); `now` is injectable for deterministic tests; falls back to a UTC-labelled reading when no usable zone is available.
- Prepended to `formatTaskList` (used by `list` and `list_all_uncompleted`) and `formatScheduleList` (zone resolved from the schedules via `resolveDisplayTimeZone`).

The zone is already resolved for rendering local times, so this is one line and **no extra API calls**. Shared code, so it lands on both the stdio and Worker entry points.

## What it helps

Correct weekday and "this week / next week / end of month" window math in the right zone; "when am I free" anchored to the real current time and correct weekday; eliminates the wrong-day-of-week class of errors.

## Tests / review

New `tests/date-context-formatter.spec.ts`: pinned-instant zone+weekday rendering, midnight local-vs-UTC day rollover, no-zone and invalid-IANA-zone fallbacks, and header presence in both formatters. Full suite (693) green; `type-check`, `worker:type-check`, and `test:types` all clean. A code-review pass found no issues at confidence ≥80 (verified timezone math, no positional-parse break, header stays out of `structuredContent`).

## Note on the related free/busy limitation

Separately researched whether a real "when am I free" (meeting-aware) tool is feasible: the **public** Motion API exposes no calendar-events, free/busy, availability, or booking endpoint. Task `scheduledStart`/`scheduledEnd` + `/schedules` working hours are the only signals a personal API key can reach; a true free/busy lives only in Motion's undocumented internal app API. So that limitation is not addressable on this API surface and is intentionally out of scope here.

https://claude.ai/code/session_01HbZLaLAKnrR3ZoZkZUk1Dn