### PR TITLE
types: add completedAfter/completedBefore to MotionTasksArgs

### DIFF
--- a/src/types/mcp-tool-args.ts
+++ b/src/types/mcp-tool-args.ts
@@ -30,6 +30,8 @@ export interface MotionTasksArgs {
   assignee?: string;
   priority?: 'ASAP' | 'HIGH' | 'MEDIUM' | 'LOW';
   dueDate?: string;
+  completedAfter?: string;
+  completedBefore?: string;
   labels?: string[];
   name?: string;
   description?: string;


### PR DESCRIPTION
Follow-on to #149. That PR added the `completedAfter` / `completedBefore` completion-date filters to `motion_tasks` across the schema (`ToolDefinitions.ts`), handler (`TaskHandler.ts`), and API layer (`services/api/tasks.ts`), but the `MotionTasksArgs` interface in `src/types/mcp-tool-args.ts` was never updated to list them. This adds the two fields so the interface matches what the tool actually accepts.

Type-only, no functional change: `MotionTasksArgs` is an interface that compiles to nothing, so the published npm package and the deployed Worker are unaffected. `main` already type-checks without it (the handler and API layer carry their own param types), so 2.9.0 did not need this to ship correctly. This is a tidy-up, not a bug fix.

This change was sitting uncommitted locally through the 2.9.0 release and was intentionally kept out of that commit.

https://claude.ai/code/session_01HbZLaLAKnrR3ZoZkZUk1Dn